### PR TITLE
Fix helmfile repos sync

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: Apply changes
         run: |
           cd home-cluster
+          helmfile repos
           helmfile deps
           helmfile sync
           kubectl apply -k .


### PR DESCRIPTION
## Summary
- Add  before  to ensure repositories are added before charts are downloaded.