### PR TITLE
Disable Renovate artifact updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,6 @@
     "config:recommended"
   ],
   "dependencyDashboard": true,
-  "prConcurrentLimit": 1
+  "prConcurrentLimit": 1,
+  "updateArtifacts": false
 }


### PR DESCRIPTION
## Summary
Disable Renovate artifact updates to fix helmfile deps failure.

The error was:


This happens because Renovate uses the GitHub Actions helm which has deprecated --client flag. Setting  tells Renovate to skip updating helmfile.lock.