### PR TITLE
Fix meshtastic-bot workflow: use kaniko

### DIFF
--- a/.github/workflows/meshtastic-bot.yaml
+++ b/.github/workflows/meshtastic-bot.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.14'
 
@@ -46,29 +46,34 @@ jobs:
     needs: test
     runs-on: self-hosted
     if: github.ref == 'refs/heads/main'
+    env:
+      PATH: /opt/tools/bin:/opt/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+      - name: Get registry credentials
+        run: |
+          REGISTRY_USER=$(kubectl get secret registry-secrets -n registry -o jsonpath='{.data.registry_username}' | base64 -d)
+          REGISTRY_PASS=$(kubectl get secret registry-secrets -n registry -o jsonpath='{.data.registry_password}' | base64 -d)
+          echo "username=$REGISTRY_USER" >> $GITHUB_ENV
+          echo "password=$REGISTRY_PASS" >> $GITHUB_ENV
 
-      - name: Login to registry
-        run: podman login ${{ env.REGISTRY }} -u registry-user -p $(kubectl get secret registry-secrets -n registry -o jsonpath='{.data.registry_password}' | base64 -d)
-
-      - name: Build and push
-        uses: docker/build-push-action@v7
-        with:
-          context: home-cluster/meshtastic-bot
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+      - name: Build and push with Kaniko
+        run: |
+          /opt/tools/kaniko executor \
+            --context home-cluster/meshtastic-bot \
+            --destination ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            --destination ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+            --registry-username ${{ env.username }} \
+            --registry-password ${{ env.password }}
 
   deploy:
     name: Deploy
     needs: build-push
     runs-on: self-hosted
+    env:
+      PATH: /opt/tools/bin:/opt/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Restart deployment
         run: kubectl rollout restart deployment meshtastic-bot -n meshtastic

--- a/home-cluster/github-runners/runner-deployment.yaml
+++ b/home-cluster/github-runners/runner-deployment.yaml
@@ -51,6 +51,9 @@ spec:
               # Install gitleaks
               curl -fsSL https://github.com/gitleaks/gitleaks/releases/download/v8.30.0/gitleaks_8.30.0_linux_x64.tar.gz | tar -xzf - -C /opt/tools/ && chmod +x /opt/tools/gitleaks
 
+              # Install kaniko (for building images in cluster)
+              curl -fsSL https://github.com/GoogleContainerTools/kaniko/releases/download/v1.19.2/executor-Linux-amd64 > /opt/tools/kaniko && chmod +x /opt/tools/kaniko
+
               ls -la /opt/tools/
           securityContext:
             runAsUser: 0


### PR DESCRIPTION
## Summary
- Replace docker/buildx with kaniko for in-cluster image building
- Get registry credentials from K8s secret
- Add kaniko to runner init container
- Add PATH env to all jobs