### PR TITLE
Add kaniko service account for in-cluster builds

### DIFF
--- a/home-cluster/github-runners/kaniko.yaml
+++ b/home-cluster/github-runners/kaniko.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kaniko
+  namespace: github-runners
+imagePullSecrets:
+  - name: registry-secrets
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kaniko
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: kaniko
+    namespace: github-runners

--- a/home-cluster/github-runners/kustomization.yaml
+++ b/home-cluster/github-runners/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - external-secrets-namespace.yaml
   - external-secrets-store.yaml
   - external-secrets.yaml
+  - kaniko.yaml


### PR DESCRIPTION
## Summary
- Add kaniko ServiceAccount with cluster-admin role
- Add imagePullSecrets for registry access
- Include in github-runners kustomization