### PR TITLE
Fix meshtastic-bot workflow: use kaniko-action

### DIFF
--- a/home-cluster/.github/workflows/ci.yaml
+++ b/home-cluster/.github/workflows/ci.yaml
@@ -1,0 +1,68 @@
+name: CI Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'home-cluster/**'
+      - 'renovate.json'
+      - '.github/workflows/**'
+      - '.gitleaks.toml'
+      - '.pre-commit-config.yaml'
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Install yamllint
+        run: pip install yamllint
+
+      - name: Lint YAML files
+        run: python3 -m yamllint -c home-cluster/yamllint.yaml home-cluster/
+
+  validate:
+    name: Validate
+    runs-on: self-hosted
+    env:
+      PATH: /opt/tools/bin:/opt/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      PYTHONPATH: /opt/tools/bin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Generate dockerconfigjson
+        run: |
+          REGISTRY_USER=$(kubectl get secret registry-secrets -n registry -o jsonpath='{.data.registry_username}' | base64 -d)
+          REGISTRY_PASS=$(kubectl get secret registry-secrets -n registry -o jsonpath='{.data.registry_password}' | base64 -d)
+          AUTH=$(echo -n "$REGISTRY_USER:$REGISTRY_PASS" | base64)
+          mkdir -p home-cluster/cluster-secrets
+          echo "{\"auths\":{\"registry.kube.stevearnett.com\":{\"username\":\"$REGISTRY_USER\",\"password\":\"$REGISTRY_PASS\",\"auth\":\"$AUTH\"}}}" > home-cluster/cluster-secrets/.dockerconfigjson
+
+      - name: Validate Kustomize
+        run: |
+          cd home-cluster
+          kubectl kustomize . 2>&1 > /dev/null && echo "Kustomize: OK" || { echo "Kustomize: FAILED"; exit 1; }
+
+  secrets:
+    name: Secret Scan
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        run: |
+          export PYTHONPATH=/opt/tools/bin
+          /opt/tools/gitleaks protect --source . --exit-code 1

--- a/home-cluster/.github/workflows/meshtastic-bot.yaml
+++ b/home-cluster/.github/workflows/meshtastic-bot.yaml
@@ -1,0 +1,83 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'home-cluster/meshtastic-bot/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'home-cluster/meshtastic-bot/**'
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Git SHA to deploy (leave empty for latest)'
+        required: false
+        type: string
+
+env:
+  REGISTRY: registry.kube.stevearnett.com
+  IMAGE_NAME: meshtastic-bot
+
+jobs:
+  test:
+    name: Test
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Install dependencies
+        run: pip install -q paho-mqtt requests meshtastic pytest
+
+      - name: Run tests
+        run: python -m pytest home-cluster/meshtastic-bot/src/test_bot.py -v
+
+  build-push:
+    name: Build and Push
+    needs: test
+    runs-on: self-hosted
+    if: github.ref == 'refs/heads/main'
+    env:
+      PATH: /opt/tools/bin:/opt/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Get registry credentials
+        run: |
+          REGISTRY_USER=$(kubectl get secret registry-secrets -n registry -o jsonpath='{.data.registry_username}' | base64 -d)
+          REGISTRY_PASS=$(kubectl get secret registry-secrets -n registry -o jsonpath='{.data.registry_password}' | base64 -d)
+          echo "REGISTRY_USER=$REGISTRY_USER" >> $GITHUB_ENV
+          echo "REGISTRY_PASS=$REGISTRY_PASS" >> $GITHUB_ENV
+
+      - name: Build and push with Kaniko
+        uses: chainguard-dev/kaniko-action@main
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: latest,${{ github.sha }}
+          context: home-cluster/meshtastic-bot
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASS }}
+
+  deploy:
+    name: Deploy
+    needs: build-push
+    runs-on: self-hosted
+    env:
+      PATH: /opt/tools/bin:/opt/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+      - name: Restart deployment
+        run: kubectl rollout restart deployment meshtastic-bot -n meshtastic
+
+      - name: Watch rollout
+        run: kubectl rollout status deployment meshtastic-bot -n meshtastic --timeout=60s

--- a/home-cluster/github-runners/runner-deployment.yaml
+++ b/home-cluster/github-runners/runner-deployment.yaml
@@ -51,8 +51,7 @@ spec:
               # Install gitleaks
               curl -fsSL https://github.com/gitleaks/gitleaks/releases/download/v8.30.0/gitleaks_8.30.0_linux_x64.tar.gz | tar -xzf - -C /opt/tools/ && chmod +x /opt/tools/gitleaks
 
-              # Install kaniko (for building images in cluster)
-              curl -fsSL https://github.com/GoogleContainerTools/kaniko/releases/download/v1.19.2/executor-Linux-amd64 > /opt/tools/kaniko && chmod +x /opt/tools/kaniko
+
 
               ls -la /opt/tools/
           securityContext:


### PR DESCRIPTION
## Summary
- Replace deprecated kaniko binary download with kaniko-action (kaniko repo is archived, binaries removed)
- Remove kaniko installation from runner init container
- Add missing ci.yaml and meshtastic-bot.yaml workflow files to git

## Changes
- `.github/workflows/meshtastic-bot.yaml`: Use `chainguard-dev/kaniko-action@main` instead of `/opt/tools/kaniko`
- `github-runners/runner-deployment.yaml`: Remove kaniko binary installation
- Added missing workflow files to git tracking