### PR TITLE
Fix: pass registry credentials to kaniko via kaniko-args

### DIFF
--- a/.github/workflows/meshtastic-bot.yaml
+++ b/.github/workflows/meshtastic-bot.yaml
@@ -77,6 +77,7 @@ jobs:
           context: home-cluster/meshtastic-bot
           file: home-cluster/meshtastic-bot/Dockerfile
           cache: true
+          kaniko-args: --registry-username=${{ env.REGISTRY_USER }} --registry-password=${{ env.REGISTRY_PASS }}
 
   deploy:
     name: Deploy


### PR DESCRIPTION
Pass registry credentials directly to kaniko executor via --registry-username and --registry-password flags