### PR TITLE
Fix: configure docker auth for kaniko directly

### DIFF
--- a/.github/workflows/meshtastic-bot.yaml
+++ b/.github/workflows/meshtastic-bot.yaml
@@ -52,20 +52,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Get registry credentials
+      - name: Configure Docker auth
         run: |
           REGISTRY_HTPASSWD=$(kubectl get secret registry-auth -n registry -o jsonpath='{.data.htpasswd}' | base64 -d)
           REGISTRY_USER=$(echo "$REGISTRY_HTPASSWD" | cut -d: -f1)
           REGISTRY_PASS=$(kubectl get secret registry-auth -n registry -o jsonpath='{.data.REGISTRY_PASSWORD}' | base64 -d)
-          echo "REGISTRY_USER=$REGISTRY_USER" >> $GITHUB_ENV
-          echo "REGISTRY_PASS=$REGISTRY_PASS" >> $GITHUB_ENV
-
-      - name: Login to registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ env.REGISTRY_USER }}
-          password: ${{ env.REGISTRY_PASS }}
+          mkdir -p ~/.docker
+          echo "{\"auths\":{\"${{ env.REGISTRY }}\":{\"auth\":\"$(echo -n "$REGISTRY_USER:$REGISTRY_PASS" | base64)\"}}}" > ~/.docker/config.json
 
       - name: Build and push with Kaniko
         uses: int128/kaniko-action@v1
@@ -77,7 +70,6 @@ jobs:
           context: home-cluster/meshtastic-bot
           file: home-cluster/meshtastic-bot/Dockerfile
           cache: true
-          kaniko-args: --registry-username=${{ env.REGISTRY_USER }} --registry-password=${{ env.REGISTRY_PASS }}
 
   deploy:
     name: Deploy


### PR DESCRIPTION
Configure docker config.json with base64-encoded credentials for kaniko