### PR TITLE
Fix: use docker/build-push-action instead of deprecated kaniko

### DIFF
--- a/.github/workflows/meshtastic-bot.yaml
+++ b/.github/workflows/meshtastic-bot.yaml
@@ -46,8 +46,6 @@ jobs:
     needs: test
     runs-on: self-hosted
     if: github.ref == 'refs/heads/main'
-    env:
-      PATH: /opt/tools/bin:/opt/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -57,20 +55,21 @@ jobs:
           REGISTRY_HTPASSWD=$(kubectl get secret registry-auth -n registry -o jsonpath='{.data.htpasswd}' | base64 -d)
           REGISTRY_USER=$(echo "$REGISTRY_HTPASSWD" | cut -d: -f1)
           REGISTRY_PASS=$(kubectl get secret registry-auth -n registry -o jsonpath='{.data.REGISTRY_PASSWORD}' | base64 -d)
-          echo "REGISTRY_USER=$REGISTRY_USER" >> $GITHUB_ENV
-          echo "REGISTRY_PASS=$REGISTRY_PASS" >> $GITHUB_ENV
           docker login ${{ env.REGISTRY }} -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
 
-      - name: Build and push with Kaniko
-        uses: int128/kaniko-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push with Docker
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           context: home-cluster/meshtastic-bot
-          file: home-cluster/meshtastic-bot/Dockerfile
-          cache: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   deploy:
     name: Deploy


### PR DESCRIPTION
Replace kaniko with docker/build-push-action which is the standard approach