### PR TITLE
Add OpenClaw AI agent

### DIFF
--- a/home-cluster/kustomization.yaml
+++ b/home-cluster/kustomization.yaml
@@ -27,3 +27,4 @@ resources:
   - kube-system/coredns-configmap-patch.yaml
   - renovate
   - github-runners
+  - openclaw

--- a/home-cluster/openclaw/deployment.yaml
+++ b/home-cluster/openclaw/deployment.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw
+  namespace: openclaw
+  labels:
+    app: openclaw
+    alert-on-down: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: openclaw
+  template:
+    metadata:
+      labels:
+        app: openclaw
+    spec:
+      serviceAccountName: openclaw
+      containers:
+      - name: openclaw
+        image: ghcr.io/openclaw/openclaw:2026.3.13-1
+        ports:
+        - containerPort: 18789
+          name: gateway
+        env:
+        - name: OLLAMA_BASE_URL
+          value: "http://ollama.ai-services.svc.cluster.local:11434"
+        - name: OPENCLAW_GATEWAY_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: openclaw-secrets
+              key: GITHUB_TOKEN
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: openclaw-secrets
+              key: GITHUB_TOKEN
+        - name: OPENCLAW_EXEC_ALLOWLIST
+          value: "cat,ls,find,grep,echo,pwd,which,git"
+        - name: SANDBOX_MODE
+          value: "docker"
+        command:
+        - sh
+        - -c
+        - |
+          openclaw config set agents.defaults.model.primary ollama/llama3.2:3b
+          openclaw config set agents.defaults.model.secondary ollama/qwen2.5-coder:14b
+          openclaw config set agents.sandbox.enabled true
+          openclaw config set agents.sandbox.mode docker
+          openclaw config set agents.github.enabled true
+          openclaw config set agents.github.defaultRepo "kg6zjl/clusters"
+          openclaw channels enable whatsapp
+          openclaw gateway --port 18789
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "2Gi"
+            cpu: "2"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 18789
+          initialDelaySeconds: 60
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 18789
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        volumeMounts:
+        - name: openclaw-data
+          mountPath: /home/node/.openclaw
+      volumes:
+      - name: openclaw-data
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw
+  namespace: openclaw
+spec:
+  type: ClusterIP
+  ports:
+  - port: 18789
+    targetPort: 18789
+    protocol: TCP
+    name: gateway
+  selector:
+    app: openclaw

--- a/home-cluster/openclaw/external-secrets.yaml
+++ b/home-cluster/openclaw/external-secrets.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openclaw-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+  target:
+    name: openclaw-secrets
+  data:
+    - secretKey: GITHUB_TOKEN
+      remoteRef:
+        key: github-runner-token
+        property: password

--- a/home-cluster/openclaw/ingressroute.yaml
+++ b/home-cluster/openclaw/ingressroute.yaml
@@ -1,0 +1,16 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: openclaw
+  namespace: openclaw
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`claw.kube.stevearnett.com`)
+      kind: Rule
+      services:
+        - name: openclaw
+          port: 18789
+  tls:
+    secretName: wildcard-stevearnett-com-tls

--- a/home-cluster/openclaw/kustomization.yaml
+++ b/home-cluster/openclaw/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - external-secrets.yaml
+  - rbac.yaml
+  - networkpolicy.yaml
+  - deployment.yaml
+  - ingressroute.yaml

--- a/home-cluster/openclaw/namespace.yaml
+++ b/home-cluster/openclaw/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openclaw
+  labels:
+    app.kubernetes.io/name: openclaw

--- a/home-cluster/openclaw/networkpolicy.yaml
+++ b/home-cluster/openclaw/networkpolicy.yaml
@@ -1,0 +1,66 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openclaw-default-deny
+  namespace: openclaw
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openclaw-allow-dns
+  namespace: openclaw
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openclaw-allow-ollama
+  namespace: openclaw
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ai-services
+    ports:
+    - protocol: TCP
+      port: 11434
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openclaw-allow-ingress
+  namespace: openclaw
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik
+    ports:
+    - protocol: TCP
+      port: 18789

--- a/home-cluster/openclaw/rbac.yaml
+++ b/home-cluster/openclaw/rbac.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openclaw
+  namespace: openclaw
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openclaw-readonly
+  namespace: openclaw
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log", "services", "configmaps", "endpoints", "events"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses", "networkpolicies"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openclaw-readonly
+  namespace: openclaw
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openclaw-readonly
+subjects:
+- kind: ServiceAccount
+  name: openclaw
+  namespace: openclaw


### PR DESCRIPTION
## Summary
Deploy OpenClaw AI agent to cluster with strict security controls.

## What's included
- **Namespace**: `openclaw`
- **Backend**: Local Ollama (`ollama.ai-services.svc.cluster.local:11434`)
- **RBAC**: Read-only role (pods, services, configmaps only - no secrets)
- **NetworkPolicy**: Block all by default, allow only Ollama + DNS + Traefik ingress
- **WhatsApp**: Enabled for messaging
- **Sandbox**: Docker sandbox mode enabled
- **GitHub**: Repo access via existing `github-runner-token` secret

## Security
- ✅ No cluster-admin
- ✅ No secret access
- ✅ No modify permissions
- ✅ Network isolated
- ✅ Sandbox execution

## TODO (after merge)
1. Deploy: `kubectl apply -k home-cluster/openclaw`
2. Watch pod: `kubectl get pods -n openclaw -w`
3. Pair WhatsApp: `kubectl exec -it -n openclaw deploy/openclaw -- openclaw channels login whatsapp`
4. Access UI: https://claw.kube.stevearnett.com