### PR TITLE
fix: remove duplicate renovate.json

### DIFF
--- a/home-cluster/renovate.json
+++ b/home-cluster/renovate.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "dependencyDashboard": true,
-  "prConcurrentLimit": 1,
-  "updateArtifacts": false
-}


### PR DESCRIPTION
## Summary
- Remove duplicate renovate.json from home-cluster directory
- Keep configuration at repository root level only
- Fixes Renovate configuration error from having multiple config files