### PR TITLE
fix: remove invalid updateArtifacts option from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,5 @@
     "config:recommended"
   ],
   "dependencyDashboard": true,
-  "prConcurrentLimit": 1,
-  "updateArtifacts": false
+  "prConcurrentLimit": 1
 }


### PR DESCRIPTION
Remove deprecated updateArtifacts:false option that is no longer valid in Renovate v43+