### PR TITLE
fix: add helm version constraint to renovate config

### DIFF
--- a/home-cluster/helmfile.yaml
+++ b/home-cluster/helmfile.yaml
@@ -371,6 +371,9 @@ releases:
               "enabledManagers": ["helmfile", "kubernetes", "helm-values"],
               "helmfile": {
                 "fileMatch": ["helmfile\\.yaml$"]
+              },
+              "constraints": {
+                "helm": "^3.15.0"
               }
             }
         existingSecret: renovate-github-token


### PR DESCRIPTION
Pin helm to ^3.15.0 to avoid --client flag deprecation error in Helm 4