### PR TITLE
fix: add helm version constraint to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,8 @@
     "config:recommended"
   ],
   "dependencyDashboard": true,
-  "prConcurrentLimit": 1
+  "prConcurrentLimit": 1,
+  "constraints": {
+    "helm": "^3.15.0"
+  }
 }


### PR DESCRIPTION
Pin helm to ^3.15.0 to fix Mend Renovate artifact update failure with Helm 4 --client flag