### PR TITLE
fix: remove hardcoded registry password from Taskfile.yaml

### DIFF
--- a/home-cluster/meshtastic-bot/Taskfile.yaml
+++ b/home-cluster/meshtastic-bot/Taskfile.yaml
@@ -4,7 +4,7 @@ tasks:
   login:
     desc: "Login to local registry"
     cmds:
-      - podman login registry.kube.stevearnett.com -u registry-user -p 7mdmjpMo5xAoub3r+kt2KK1kNBE=
+      - podman login registry.kube.stevearnett.com -u registry-user --password-stdin <<< "${REGISTRY_PASSWORD}"
 
   build:
     desc: "Build Docker image (runs tests first)"


### PR DESCRIPTION
Use --password-stdin with REGISTRY_PASSWORD env var instead of hardcoded password