### PR TITLE
fix: remove onepassword secretGenerator from github-runners

### DIFF
--- a/home-cluster/github-runners/kustomization.yaml
+++ b/home-cluster/github-runners/kustomization.yaml
@@ -2,11 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 generatorOptions:
   disableNameSuffixHash: true
-secretGenerator:
-  - name: onepassword
-    namespace: external-secrets
-    envs:
-      - onepassword.env
 resources:
   - namespace.yaml
   - rbac.yaml


### PR DESCRIPTION
Remove reference to deleted onepassword.env file