### PR TITLE
fix: add helmfile packageRules for Mend Renovate helm constraint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,13 @@
   "prConcurrentLimit": 1,
   "constraints": {
     "helm": "^3.15.0"
-  }
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["helmfile"],
+      "constraints": {
+        "helm": "^3.15.0"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Add packageRules for helmfile manager to enforce helm ^3.15.0 constraint for Mend Renovate