### PR TITLE
feat(openclaw): OpenRouter model, persistent storage, GitHub token

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,8 @@ grep -rE "password|secret|token|key|auth|credential" --include="*.yaml" . | grep
 
 If this check fails, fix it immediately before committing.
 
+**TODO**: Add `trufflehog` or `detect-secrets` for intelligent key-value pair detection in addition to gitleaks.
+
 Manual backup can be triggered with:
 ```bash
 kubectl create job -n backup --from=cronjob/pvc-backup pvc-backup-manual

--- a/home-cluster/openclaw/deployment.yaml
+++ b/home-cluster/openclaw/deployment.yaml
@@ -26,26 +26,33 @@ spec:
         - containerPort: 18789
           name: gateway
         env:
-        - name: OLLAMA_BASE_URL
-          value: "http://ollama-amd-02.ai-services.svc.cluster.local:11434"
-        - name: OLLAMA_API_KEY
+        - name: OPENROUTER_API_KEY
           valueFrom:
             secretKeyRef:
               name: openclaw-secrets
-              key: OLLAMA_API_KEY
+              key: OPENROUTER_API_KEY
         - name: OPENCLAW_GATEWAY_TOKEN
           valueFrom:
             secretKeyRef:
               name: openclaw-secrets
               key: GATEWAY_TOKEN
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: openclaw-secrets
+              key: GITHUB_TOKEN
         command:
         - sh
         - -c
         - |
-          cat > /home/node/.openclaw/openclaw.json << 'EOF'
+          cat > /home/node/.openclaw/openclaw.json << EOF
           {
             "gateway": {
               "mode": "local",
+              "auth": {
+                "mode": "token",
+                "token": "${OPENCLAW_GATEWAY_TOKEN}"
+              },
               "trustedProxies": ["10.0.0.0/8", "192.168.0.0/16"],
               "controlUi": {
                 "allowInsecureAuth": true,
@@ -71,8 +78,9 @@ spec:
             },
             "models": {
               "providers": {
-                "ollama": {
-                  "baseUrl": "http://ollama-amd-02.ai-services.svc.cluster.local:11434",
+                "openrouter": {
+                  "baseUrl": "https://openrouter.ai/api/v1",
+                  "apiKey": "${OPENROUTER_API_KEY}",
                   "models": []
                 }
               }
@@ -80,7 +88,7 @@ spec:
             "agents": {
               "defaults": {
                 "model": {
-                  "primary": "llama3.2:1b"
+                  "primary": "openrouter/google/gemini-3-flash-preview"
                 }
               }
             }
@@ -109,17 +117,39 @@ spec:
         volumeMounts:
         - name: openclaw-data
           mountPath: /home/node/.openclaw
+        - name: user-files
+          mountPath: /home/node/.openclaw/workspace/USER.md
+          subPath: USER.md
       volumes:
       - name: openclaw-data
-        emptyDir: {}
+        persistentVolumeClaim:
+          claimName: openclaw-data
+      - name: user-files
+        configMap:
+          name: openclaw-user-files
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openclaw-data
+  namespace: openclaw
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: microk8s-hostpath
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: openclaw
   namespace: openclaw
+  annotations:
+    metallb.universe.tf/address-pool: default-addresspool
 spec:
-  type: ClusterIP
+  type: LoadBalancer
   ports:
   - port: 18789
     targetPort: 18789

--- a/home-cluster/openclaw/external-secrets.yaml
+++ b/home-cluster/openclaw/external-secrets.yaml
@@ -19,3 +19,11 @@ spec:
       remoteRef:
         key: openclaw-ollama-api-key
         property: password
+    - secretKey: OPENROUTER_API_KEY
+      remoteRef:
+        key: openrouter-api-key
+        property: password
+    - secretKey: GITHUB_TOKEN
+      remoteRef:
+        key: github-runner-token
+        property: password

--- a/home-cluster/openclaw/ingressroute.yaml
+++ b/home-cluster/openclaw/ingressroute.yaml
@@ -12,5 +12,7 @@ spec:
       services:
         - name: openclaw
           port: 18789
+          scheme: http
+          serversTransport: openclaw-http11
   tls:
     secretName: wildcard-stevearnett-com-tls

--- a/home-cluster/openclaw/kustomization.yaml
+++ b/home-cluster/openclaw/kustomization.yaml
@@ -1,3 +1,5 @@
+# OpenClaw - 100% Declarative
+# All configuration lives in git. No manual pod exec edits.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -7,3 +9,4 @@ resources:
   - networkpolicy.yaml
   - deployment.yaml
   - ingressroute.yaml
+  - usermap.yaml

--- a/home-cluster/openclaw/networkpolicy-external.yaml
+++ b/home-cluster/openclaw/networkpolicy-external.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openclaw-allow-external
+  namespace: openclaw
+spec:
+  podSelector: 
+  ingress:
+  - ports:
+    - port: 18789
+      protocol: TCP
+  policyTypes:
+  - Ingress

--- a/home-cluster/openclaw/serverstransport.yaml
+++ b/home-cluster/openclaw/serverstransport.yaml
@@ -1,0 +1,7 @@
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: openclaw-http11
+  namespace: openclaw
+spec:
+  disableHTTP2: true

--- a/home-cluster/openclaw/tlsoption.yaml
+++ b/home-cluster/openclaw/tlsoption.yaml
@@ -1,0 +1,8 @@
+apiVersion: traefik.io/v1alpha1
+kind: TLSOption
+metadata:
+  name: openclaw-tls-option
+  namespace: openclaw
+spec:
+  alpnProtocols:
+    - http/1.1

--- a/home-cluster/openclaw/usermap.yaml
+++ b/home-cluster/openclaw/usermap.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-user-files
+  namespace: openclaw
+data:
+  USER.md: |
+    # Lead Chef
+
+    ## About Me
+
+    I am a Christian, husband, and father of two. I love tinkering with technology and building things in my homelab.
+
+    ## My Family
+    - Married to my wonderful wife
+    - Dad to two kids
+
+    ## My Interests
+    - **Technology**: Home automation, homelab infrastructure, Kubernetes, self-hosting
+    - **Tinkering**: Building and maintaining my own infrastructure
+    - **Faith**: Following Jesus
+
+    ## My Setup
+    - **Kubernetes cluster** with multiple nodes:
+      - AMD Acemagicial K1 (main cluster node)
+      - ThinkCentre 01 (worker node)
+      - ThinkCentre 02 (worker node, running Ollama for AI services)
+      - Beast (gaming rig with massive GPU, often offline)
+    - Running services for home automation, media, monitoring, and AI
+    - Everything self-hosted where possible
+
+    ## Working With Me
+    - I appreciate practical solutions over complex ones
+    - Keep explanations concise
+    - I like to understand *why* not just *what*
+    - As the Lead Chef, I direct the work - you're my assistant making things happen
+
+    ## Communication Style
+    - Direct and to the point
+    - Prefer doing over talking
+    - Technical but accessible
+
+    ## Infrastructure Note
+    - All homelab configuration is 100% declarative (in git)
+    - No manual pod exec edits - everything defined in code


### PR DESCRIPTION
## Summary
- Switch model provider from Ollama to OpenRouter (gemini-3-flash-preview)
- Add PVC for persistent session storage
- Add GITHUB_TOKEN from 1Password
- Add USER.md ConfigMap for declarative user profile
- Add network policies for external access

## Changes
- `deployment.yaml`: OpenRouter config, GITHUB_TOKEN env var, PVC mount
- `external-secrets.yaml`: OPENROUTER_API_KEY, GITHUB_TOKEN secrets
- `usermap.yaml`: Declarative USER.md ConfigMap
- `networkpolicy-external.yaml`: Allow external HTTP/HTTPS access
- `kustomization.yaml`: Reference new resources

## Testing
- [x] Pod starts and connects to OpenRouter
- [x] PVC mounts correctly
- [x] USER.md accessible in workspace