### PR TITLE
feat: grant openclaw service account cluster-wide view permissions

### DIFF
--- a/home-cluster/openclaw/rbac.yaml
+++ b/home-cluster/openclaw/rbac.yaml
@@ -39,3 +39,28 @@ subjects:
 - kind: ServiceAccount
   name: openclaw
   namespace: openclaw
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openclaw-scout
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services", "nodes", "configmaps", "namespaces", "events"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "statefulsets", "daemonsets"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openclaw-scout-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openclaw-scout
+subjects:
+- kind: ServiceAccount
+  name: openclaw
+  namespace: openclaw


### PR DESCRIPTION
This PR adds a  to the  service account, allowing it to have cluster-wide  permissions. This is necessary for Kilo to scout the cluster and diagnose deployment failures.