### PR TITLE
fix(onepassword): add credentials and token mapping to onepassword-connect

### DIFF
--- a/home-cluster/helmfile.yaml
+++ b/home-cluster/helmfile.yaml
@@ -674,7 +674,12 @@ releases:
       - connect:
           create: true
           replicas: 1
+          credentials: onepassword-credentials.json
+          credentialsName: op-credentials
         operator:
           create: true
+          token:
+            name: onepassword-connect-token
+            key: token
         service:
           type: ClusterIP


### PR DESCRIPTION
This PR updates the Helm values for onepassword-connect to properly map the credentials JSON and the connection token. It points specifically to the `op-credentials` secret and the `onepassword-connect-token` secret created during bootstrap.