### PR TITLE
fix(networkpolicy): add DNS access to kube-api policies

### DIFF
--- a/home-cluster/github-runners/networkpolicy-kube-api.yaml
+++ b/home-cluster/github-runners/networkpolicy-kube-api.yaml
@@ -9,6 +9,13 @@ spec:
   - Egress
   egress:
   - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
+  - to:
     - ipBlock:
         cidr: 0.0.0.0/0
     ports:

--- a/home-cluster/openclaw/networkpolicy-kube-api.yaml
+++ b/home-cluster/openclaw/networkpolicy-kube-api.yaml
@@ -9,6 +9,13 @@ spec:
   - Egress
   egress:
   - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
+  - to:
     - ipBlock:
         cidr: 0.0.0.0/0  # Broad for now to ensure API reachability
     ports:


### PR DESCRIPTION
## Summary
- Add DNS (port 53 TCP/UDP) to network policies for github-runners and openclaw namespaces
- Controllers need DNS to resolve `kubernetes.default.svc` before reaching the API server

## Changes
- `home-cluster/github-runners/networkpolicy-kube-api.yaml`
- `home-cluster/openclaw/networkpolicy-kube-api.yaml`