### PR TITLE
fix(helm): remove atomic deploy to allow non-blocking updates

### DIFF
--- a/home-cluster/helmfile.yaml
+++ b/home-cluster/helmfile.yaml
@@ -44,7 +44,6 @@ repositories:
 ---
 helmDefaults:
   historyMax: 3
-  atomic: true
   cleanupOnFail: true
   timeout: 900
 ---


### PR DESCRIPTION
This PR removes `atomic: true` from the global `helmDefaults`. This stops Helm from blocking the entire deployment pipeline when a single release (like Pi-hole or GPU Operator) takes too long to reach a ready state or requires a manual restart.