### PR TITLE
fix(openclaw): correct YAML indentation in scout RBAC

### DIFF
--- a/home-cluster/openclaw/rbac.yaml
+++ b/home-cluster/openclaw/rbac.yaml
@@ -40,7 +40,7 @@ metadata:
   name: openclaw-scout
 rules:
 - apiGroups: [""]
-  - resources: ["pods", "services", "nodes", "configmaps", "namespaces", "events", "runnerdeployments"]
+  resources: ["pods", "services", "nodes", "configmaps", "namespaces", "events", "runnerdeployments"]
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["pods/log"]


### PR DESCRIPTION
## Summary
- Fix YAML indentation issue in openclaw/rbac.yaml (removed errant space before `resources` key)