### PR TITLE
fix(headlamp): remove static kubeconfig to enable cluster-admin access

### DIFF
--- a/home-cluster/headlamp/deployment.yaml
+++ b/home-cluster/headlamp/deployment.yaml
@@ -20,7 +20,6 @@ spec:
       - name: headlamp
         image: ghcr.io/headlamp-k8s/headlamp:latest
         args:
-        - -kubeconfig=/etc/kubeconfig/config
         - -plugins-dir=/headlamp/plugins
         ports:
         - containerPort: 4466


### PR DESCRIPTION
Audited the Headlamp code and found it was using a static kubeconfig file instead of the pod's ServiceAccount. This PR removes the manual kubeconfig flag, allowing Headlamp to use its `cluster-admin` ServiceAccount correctly. This should fix the 404 errors for cluster resources like NetworkPolicies.