### PR TITLE
fix(github-runners): allow HTTP port 80 for Alpine package downloads

### DIFF
--- a/home-cluster/github-runners/networkpolicy-kube-api.yaml
+++ b/home-cluster/github-runners/networkpolicy-kube-api.yaml
@@ -14,3 +14,5 @@ spec:
     ports:
     - protocol: TCP
       port: 443
+    - protocol: TCP
+      port: 80


### PR DESCRIPTION
## Summary
- Add port 80 (HTTP) to the GitHub runner NetworkPolicy egress rules

## Root Cause
The runner's `initContainers` use Alpine's `apk` package manager which fetches packages from `dl-cdn.alpinelinux.org`. The NetworkPolicy only allowed port 443 (HTTPS), but `apk` uses HTTP on port 80, causing the init container to fail with:

```
WARNING: fetching https://dl-cdn.alpinelinux.org/alpine/v3.19/main: temporary error (try again later)
ERROR: unable to select packages: bash (no such package)
```

This prevented new runner pods from starting, leaving only 1 runner online while CI workflows queued up.

## Fix
Add TCP port 80 to the egress rules in `github-runners/networkpolicy-kube-api.yaml`.