### PR TITLE
fix(github-runners): allow DNS egress for pod resolution

### DIFF
--- a/home-cluster/github-runners/networkpolicy-kube-api.yaml
+++ b/home-cluster/github-runners/networkpolicy-kube-api.yaml
@@ -9,6 +9,13 @@ spec:
   - Egress
   egress:
   - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
+  - to:
     - ipBlock:
         cidr: 0.0.0.0/0
     ports:


### PR DESCRIPTION
## Summary
- Add DNS egress rules (TCP/UDP port 53) to the GitHub runner NetworkPolicy

## Root Cause
DNS resolution was blocked. Without port 53 (DNS), pods couldn't resolve external hostnames like `dl-cdn.alpinelinux.org`, causing `apk` package downloads to fail.

## Fix
Added egress rules allowing DNS traffic to all namespaces:
- TCP port 53
- UDP port 53