### PR TITLE
fix(openclaw): enable internal registry access for Scout

### DIFF
--- a/home-cluster/openclaw/networkpolicy.yaml
+++ b/home-cluster/openclaw/networkpolicy.yaml
@@ -69,6 +69,23 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: openclaw-allow-control-plane
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openclaw-allow-registry
+  namespace: openclaw
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 10.152.183.235/32
+    ports:
+    - protocol: TCP
+      port: 5000
   namespace: openclaw
 spec:
   podSelector: {}


### PR DESCRIPTION
Test results confirmed that both Scout and potentially the Runners are blind to the internal registry ClusterIP. This PR allows explicit egress to the Registry's current IP (10.152.183.235) on port 5000.