### PR TITLE
fix(github-runners): allow kube-apiserver egress for kubectl access

### DIFF
--- a/home-cluster/github-runners/networkpolicy-kube-api.yaml
+++ b/home-cluster/github-runners/networkpolicy-kube-api.yaml
@@ -29,3 +29,7 @@ spec:
       port: 443
     - protocol: TCP
       port: 80
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53


### PR DESCRIPTION
## Summary
- Add egress rule for kube-apiserver (10.152.183.0/24:443)

## Root Cause
Without explicit access to the Kubernetes API server, `kubectl` commands fail with:
```
dial tcp 10.152.183.1:443: i/o timeout
```

## Fix
Added egress rule allowing TCP port 443 to the cluster service CIDR (10.152.183.0/24).