### PR TITLE
fix(openclaw): remove duplicate networkpolicy resource

### DIFF
--- a/home-cluster/openclaw/networkpolicy.yaml
+++ b/home-cluster/openclaw/networkpolicy.yaml
@@ -69,11 +69,6 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: openclaw-allow-control-plane
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: openclaw-allow-control-plane
   namespace: openclaw
 spec:
   podSelector: {}


### PR DESCRIPTION
Removes the duplicate and malformed `openclaw-allow-control-plane` NetworkPolicy from the `home-cluster` that was causing Kustomize build failures in CI.