### PR TITLE
ci(secrets): add Trufflehog secret scanning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,3 +66,11 @@ jobs:
         run: |
           export PYTHONPATH=/opt/tools/bin
           /opt/tools/gitleaks protect --source . --exit-code 1
+
+      - name: Run Trufflehog
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --debug --only-verified


### PR DESCRIPTION
Enhances the CI pipeline by adding Trufflehog for deeper secret scanning, supplementing the existing Gitleaks check. This provides better detection for verified secrets and complex key-value pairs.