### PR TITLE
fix(arc): mainline ARC migration (corrected)

### DIFF
--- a/home-cluster/helmfile.yaml
+++ b/home-cluster/helmfile.yaml
@@ -32,7 +32,7 @@ repositories:
   - name: actions-runner-controller
     url: https://actions-runner-controller.github.io/actions-runner-controller
   - name: actions-runner-controller-mainline
-    url: https://actions-runner-controller.github.io/actions-runner-controller
+    url: oci://ghcr.io/actions/actions-runner-controller
   - name: external-secrets
     url: https://charts.external-secrets.io
   - name: 1password


### PR DESCRIPTION
## Overview
Corrects the mainline ARC migration by using the proper **OCI registry** for Helm charts (`oci://ghcr.io/actions/actions-runner-controller`).

## 🧱 Key Changes
- Updated `home-cluster/helmfile.yaml` with the correct OCI URL.
- Merged latest `main` changes including optimized Dockerfile and CI policies.

This should resolve the 'chart not found' errors in the deploy pipeline.