### PR TITLE
ci: add timeout to dockerconfigjson generation

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Generate dockerconfigjson
+        timeout-minutes: 1
         run: |
           REGISTRY_PASS=$(kubectl get secret registry-secrets -n registry -o jsonpath='{.data.REGISTRY_PASSWORD}' | base64 -d)
           REGISTRY_USER=$(kubectl get secret registry-secrets -n registry -o jsonpath='{.data.htpasswd}' | base64 -d | cut -d: -f1)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Generate dockerconfigjson
+        timeout-minutes: 1
         run: |
           REGISTRY_PASS=$(kubectl get secret registry-secrets -n registry -o jsonpath='{.data.REGISTRY_PASSWORD}' | base64 -d)
           REGISTRY_USER=$(kubectl get secret registry-secrets -n registry -o jsonpath='{.data.htpasswd}' | base64 -d | cut -d: -f1)


### PR DESCRIPTION
Adds a 1-minute timeout to the `Generate dockerconfigjson` step in both CI and Apply workflows. This prevents the job from hanging indefinitely if it can't reach the cluster's `kubectl`.