### PR TITLE
fix(github-runners): remove stale /runner/run.sh command override

### DIFF
--- a/home-cluster/github-runners/runner-deployment.yaml
+++ b/home-cluster/github-runners/runner-deployment.yaml
@@ -61,7 +61,6 @@ spec:
       containers:
         - name: runner
           image: summerwind/actions-runner:latest
-          command: ["/runner/run.sh"]
           env:
             - name: DOCKER_HOST
               value: unix:///var/run/docker.sock


### PR DESCRIPTION
## Summary
- The `summerwind/actions-runner:latest` image has changed and no longer contains `/runner/run.sh`
- This was causing new runner pods to fail with: `stat /runner/run.sh: no such file or directory`
- Removing the command override allows the container to use its default entrypoint

## Testing
- Kustomize validation passes
- Existing running runner (github-runner-cwqbt-pjftk) continues to work