### PR TITLE
fix(github-runners): use external API server IP

### DIFF
--- a/home-cluster/github-runners/runner-deployment.yaml
+++ b/home-cluster/github-runners/runner-deployment.yaml
@@ -62,6 +62,10 @@ spec:
         - name: runner
           image: summerwind/actions-runner:latest
           env:
+            - name: KUBERNETES_SERVICE_HOST
+              value: "192.168.1.96"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "16443"
             - name: DOCKER_HOST
               value: unix:///var/run/docker.sock
           volumeMounts:


### PR DESCRIPTION
## Summary
The runner pods cannot reach the internal Kubernetes API at 10.152.183.1 due to a networking issue. This PR adds environment variables to direct Kubernetes API traffic to the external API endpoint (192.168.1.96:16443).

## Testing
- Kustomize validation should pass
- CI will test if the runners can now reach the API