### PR TITLE
fix(workflow): explicitly set PATH in each step

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Rollback pending releases
         run: |
+          export PATH="/opt/tools/bin:/opt/tools:$PATH"
           helm list -A --pending 2>/dev/null | awk 'NR>1 {print $1, $2}' | \
             while read -r release namespace; do
               echo "Attempting to fix pending release: $release in $namespace"
@@ -40,6 +41,7 @@ jobs:
 
       - name: Apply changes
         run: |
+          export PATH="/opt/tools/bin:/opt/tools:$PATH"
           cd home-cluster
           helmfile repos
           helmfile deps


### PR DESCRIPTION
## Summary
The runner container's PATH doesn't include /opt/tools where helm, helmfile, and kubectl are installed. Explicitly export PATH in each workflow step to ensure these tools are available.

## Testing
- CI should now successfully run helmfile and kubectl commands