### PR TITLE
Fix CI: Delete stale Flux CRDs before apply

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -40,6 +40,17 @@ jobs:
               echo "Warning: Could not fix pending release $release in $namespace"
             done
 
+      - name: Delete stale Flux CRDs
+        run: |
+          for crd in helmcharts helmreleases helmrepositories ocirepositories; do
+            echo "Checking flux CRDs with v1beta2 for $crd..."
+            STORED=$(kubectl get crd ${crd}.source.toolkit.fluxcd.io -o jsonpath='{.status.storedVersions}' 2>/dev/null)
+            if echo "$STORED" | grep -q v1beta2; then
+              echo "Deleting stale CRD ${crd}.source.toolkit.fluxcd.io (has v1beta2)"
+              kubectl delete crd ${crd}.source.toolkit.fluxcd.io --ignore-not-found
+            fi
+          done
+
       - name: Apply changes
         run: |
           export PATH="/opt/tools/bin:/opt/tools:$PATH"
@@ -47,4 +58,4 @@ jobs:
           helmfile repos
           helmfile deps
           helmfile sync
-          kubectl apply -k .
+          kubectl apply -k . --server-side


### PR DESCRIPTION
## Summary
- Add pre-apply step to delete Flux CRDs with stale v1beta2 storage version
- Use `--server-side` apply for better CRD handling

## Problem
CI fails when applying Flux CRDs because:
1. Old CRDs have `v1beta2` as storage version
2. New Flux v2.8.3 CRDs only support `v1`
3. `kubectl apply` can't patch CRDs to remove v1beta2 from storedVersions

## Solution
1. Before applying manifests, check for and delete CRDs with v1beta2
2. Use `--server-side` apply which handles CRD updates better

## Testing
- Manually applied same fix to cluster (PR #208)
- All Flux controllers now running
- GitRepository synced successfully