### PR TITLE
Fix runner PATH to include /opt/tools

### DIFF
--- a/home-cluster/github-runners/runner-deployment.yaml
+++ b/home-cluster/github-runners/runner-deployment.yaml
@@ -64,6 +64,8 @@ spec:
           env:
             - name: DOCKER_HOST
               value: unix:///var/run/docker.sock
+            - name: PATH
+              value: /opt/tools:/opt/tools/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           volumeMounts:
             - mountPath: /var/run
               name: docker-sock


### PR DESCRIPTION
Adds PATH env var to runner container to include /opt/tools where kubectl, helm, etc. are installed.