### PR TITLE
Migrate speedtest to Flux GitOps

### DIFF
--- a/home-cluster/flux-system/syncs/kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - clusters-gitrepository.yaml
   - netalertx-kustomization.yaml
   - quotes-kustomization.yaml
+  - speedtest-kustomization.yaml

--- a/home-cluster/flux-system/syncs/speedtest-kustomization.yaml
+++ b/home-cluster/flux-system/syncs/speedtest-kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: speedtest
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  path: ./home-cluster/speedtest
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters
+  targetNamespace: speedtest
+  timeout: 2m0s

--- a/home-cluster/kustomization.yaml
+++ b/home-cluster/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
   - media
   - vpn
   - cloudflared
-  - speedtest
+  # - speedtest (managed by Flux)
   - local-services
   - registry
   # - netalertx


### PR DESCRIPTION
Migrates speedtest service to Flux GitOps management.

- Adds speedtest Kustomization to flux-system/syncs
- Removes speedtest from root kustomization