### PR TITLE
Migrate headlamp to Flux GitOps

### DIFF
--- a/home-cluster/flux-system/syncs/headlamp-kustomization.yaml
+++ b/home-cluster/flux-system/syncs/headlamp-kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: headlamp
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  path: ./home-cluster/headlamp
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters
+  targetNamespace: headlamp
+  timeout: 2m0s

--- a/home-cluster/flux-system/syncs/kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - netalertx-kustomization.yaml
   - quotes-kustomization.yaml
   - speedtest-kustomization.yaml
+  - headlamp-kustomization.yaml

--- a/home-cluster/kustomization.yaml
+++ b/home-cluster/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
   - registry
   # - netalertx
   # - quotes (managed by Flux)
-  - headlamp
+  # - headlamp (managed by Flux)
   - frigate
   - mqtt
   - meshtastic


### PR DESCRIPTION
Migrates headlamp service to Flux GitOps management.