### PR TITLE
Migrate meshtastic-bot to Flux GitOps

### DIFF
--- a/home-cluster/flux-system/syncs/kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - mqtt-kustomization.yaml
   - frigate-kustomization.yaml
   - meshtastic-kustomization.yaml
+  - meshtastic-bot-kustomization.yaml

--- a/home-cluster/flux-system/syncs/meshtastic-bot-kustomization.yaml
+++ b/home-cluster/flux-system/syncs/meshtastic-bot-kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: meshtastic-bot
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  path: ./home-cluster/meshtastic-bot
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters
+  targetNamespace: meshtastic
+  timeout: 2m0s

--- a/home-cluster/kustomization.yaml
+++ b/home-cluster/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
   # - frigate (managed by Flux)
   # - mqtt (managed by Flux)
   # - meshtastic (managed by Flux)
-  - meshtastic-bot
+  # - meshtastic-bot (managed by Flux)
   # - pihole (managed by Flux)
   - kube-system/coredns-configmap-patch.yaml
   - kube-system/dnsendpoint-openclaw.yaml


### PR DESCRIPTION
Migrates meshtastic-bot service to Flux GitOps management.