### PR TITLE
Migrate openclaw to Flux GitOps

### DIFF
--- a/home-cluster/flux-system/syncs/kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - frigate-kustomization.yaml
   - meshtastic-kustomization.yaml
   - meshtastic-bot-kustomization.yaml
+  - openclaw-kustomization.yaml

--- a/home-cluster/flux-system/syncs/openclaw-kustomization.yaml
+++ b/home-cluster/flux-system/syncs/openclaw-kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: openclaw
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  path: ./home-cluster/openclaw
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters
+  targetNamespace: openclaw
+  timeout: 2m0s

--- a/home-cluster/kustomization.yaml
+++ b/home-cluster/kustomization.yaml
@@ -26,8 +26,8 @@ resources:
   # - meshtastic (managed by Flux)
   # - meshtastic-bot (managed by Flux)
   # - pihole (managed by Flux)
+  # - openclaw (managed by Flux)
   - kube-system/coredns-configmap-patch.yaml
   - kube-system/dnsendpoint-openclaw.yaml
   - renovate
   - github-runners
-  - openclaw


### PR DESCRIPTION
Migrates openclaw service to Flux GitOps management.