### PR TITLE
Migrate oauth2-proxy to Flux GitOps

### DIFF
--- a/home-cluster/flux-system/syncs/kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - cloudflared-kustomization.yaml
   - local-services-kustomization.yaml
   - registry-kustomization.yaml
+  - oauth2-proxy-kustomization.yaml

--- a/home-cluster/flux-system/syncs/oauth2-proxy-kustomization.yaml
+++ b/home-cluster/flux-system/syncs/oauth2-proxy-kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: oauth2-proxy
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  path: ./home-cluster/oauth2-proxy
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters
+  targetNamespace: auth
+  timeout: 2m0s

--- a/home-cluster/kustomization.yaml
+++ b/home-cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - flux-system/syncs
   - traefik
   - cert-manager
-  - oauth2-proxy
+  # - oauth2-proxy (managed by Flux)
   - cluster-secrets
   - monitoring
   - home-assistant


### PR DESCRIPTION
Migrates oauth2-proxy to Flux GitOps management.