### PR TITLE
migrate(vpn): move to Flux GitOps

### DIFF
--- a/home-cluster/flux-system/syncs/kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
   - registry-kustomization.yaml
   - oauth2-proxy-kustomization.yaml
   - plex-kustomization.yaml
+  - vpn-kustomization.yaml

--- a/home-cluster/flux-system/syncs/vpn-kustomization.yaml
+++ b/home-cluster/flux-system/syncs/vpn-kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: vpn
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  path: ./home-cluster/vpn
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters
+  targetNamespace: vpn
+  timeout: 2m0s

--- a/home-cluster/kustomization.yaml
+++ b/home-cluster/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
   - gpu-operator
   # - plex (managed by Flux)
   - media
-  - vpn
+  # - vpn (managed by Flux)
   # - cloudflared (managed by Flux)
   # - speedtest (managed by Flux)
   # - local-services (managed by Flux)


### PR DESCRIPTION
## Summary
- Add Flux Kustomization for vpn namespace
- Remove vpn from root kustomization.yaml