### PR TITLE
migrate(home-assistant): move to Flux GitOps

### DIFF
--- a/home-cluster/flux-system/syncs/home-assistant-kustomization.yaml
+++ b/home-cluster/flux-system/syncs/home-assistant-kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: home-assistant
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  path: ./home-cluster/home-assistant
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/home-cluster/flux-system/syncs/kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kustomization.yaml
@@ -19,3 +19,4 @@ resources:
   - oauth2-proxy-kustomization.yaml
   - plex-kustomization.yaml
   - vpn-kustomization.yaml
+  - home-assistant-kustomization.yaml

--- a/home-cluster/kustomization.yaml
+++ b/home-cluster/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
   # - oauth2-proxy (managed by Flux)
   - cluster-secrets
   - monitoring
-  - home-assistant
+  # - home-assistant (managed by Flux)
   - ai-services
   - gpu-operator
   # - plex (managed by Flux)


### PR DESCRIPTION
## Summary
- Add Flux Kustomization for home-assistant namespace
- Remove home-assistant from root kustomization.yaml