### PR TITLE
migrate(renovate): move to Flux GitOps

### DIFF
--- a/home-cluster/flux-system/syncs/kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
   - plex-kustomization.yaml
   - vpn-kustomization.yaml
   - home-assistant-kustomization.yaml
+  - renovate-kustomization.yaml

--- a/home-cluster/flux-system/syncs/renovate-kustomization.yaml
+++ b/home-cluster/flux-system/syncs/renovate-kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: renovate
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  path: ./home-cluster/renovate
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/home-cluster/kustomization.yaml
+++ b/home-cluster/kustomization.yaml
@@ -29,5 +29,5 @@ resources:
   # - openclaw (managed by Flux)
   - kube-system/coredns-configmap-patch.yaml
   - kube-system/dnsendpoint-openclaw.yaml
-  - renovate
+  # - renovate (managed by Flux)
   - github-runners


### PR DESCRIPTION
## Summary
- Add Flux Kustomization for renovate namespace
- Remove renovate from root kustomization.yaml