### PR TITLE
fix(oauth2-proxy): resolve emails file mount error

### DIFF
--- a/home-cluster/oauth2-proxy/external-secrets.yaml
+++ b/home-cluster/oauth2-proxy/external-secrets.yaml
@@ -35,7 +35,7 @@ spec:
   target:
     name: oauth2-proxy-emails
   data:
-    - secretKey: authenticated-emails
+    - secretKey: .env.authenticated-emails
       remoteRef:
         key: oauth2-proxy-authenticated-emails
         property: password


### PR DESCRIPTION
## Overview
Fixes the `CrashLoopBackOff` in the `auth` namespace where `oauth2-proxy` couldn't find its authenticated emails file.

## 🧱 Changes
- Updated `oauth2-proxy-emails` ExternalSecret to use `.env.authenticated-emails` as the secret key.
- This ensures the file is created at `/etc/oauth2-proxy/.env.authenticated-emails`, matching the proxy's startup arguments.