### PR TITLE
feat(arc): migrate mainline ARC to Flux GitOps

### DIFF
--- a/home-cluster/arc-runners/helmrelease.yaml
+++ b/home-cluster/arc-runners/helmrelease.yaml
@@ -1,0 +1,37 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: arc-runner-set
+  namespace: arc-runners
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: gha-runner-scale-set
+      version: 0.9.3
+      sourceRef:
+        kind: HelmRepository
+        name: actions-runner-controller-mainline
+        namespace: flux-system
+  install:
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 3
+  dependsOn:
+    - name: arc-operator
+      namespace: arc-systems
+  values:
+    githubConfigUrl: "https://github.com/kg6zjl/clusters"
+    githubConfigSecret: github-runner-secret
+    minReplicas: 2
+    maxReplicas: 5
+    controllerServiceAccount:
+      name: arc-operator-gha-runner-scale-set-controller
+      namespace: arc-systems
+    template:
+      spec:
+        containers:
+          - name: runner
+            image: registry.kube.stevearnett.com/github-runner-optimized:latest
+            command: ["/home/runner/run.sh"]

--- a/home-cluster/arc-runners/kustomization.yaml
+++ b/home-cluster/arc-runners/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/home-cluster/arc-systems/helmrelease.yaml
+++ b/home-cluster/arc-systems/helmrelease.yaml
@@ -1,0 +1,21 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: arc-operator
+  namespace: arc-systems
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: gha-runner-scale-set-controller
+      version: 0.9.3
+      sourceRef:
+        kind: HelmRepository
+        name: actions-runner-controller-mainline
+        namespace: flux-system
+  install:
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 3
+  values: {}

--- a/home-cluster/arc-systems/kustomization.yaml
+++ b/home-cluster/arc-systems/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/home-cluster/flux-system/arc-helmrepository.yaml
+++ b/home-cluster/flux-system/arc-helmrepository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: actions-runner-controller-mainline
+  namespace: flux-system
+spec:
+  interval: 1h
+  type: oci
+  url: oci://ghcr.io/actions/actions-runner-controller

--- a/home-cluster/flux-system/kustomization.yaml
+++ b/home-cluster/flux-system/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: flux-system
 resources:
   - gotk-components.yaml
+  - arc-helmrepository.yaml

--- a/home-cluster/flux-system/syncs/arc-kustomization.yaml
+++ b/home-cluster/flux-system/syncs/arc-kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: arc-systems
+  namespace: flux-system
+spec:
+  interval: 1h
+  path: ./home-cluster/arc-systems
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: arc-runners
+  namespace: flux-system
+spec:
+  interval: 1h
+  path: ./home-cluster/arc-runners
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters
+  dependsOn:
+    - name: arc-systems

--- a/home-cluster/flux-system/syncs/kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kustomization.yaml
@@ -23,3 +23,4 @@ resources:
   - renovate-kustomization.yaml
   - ai-services-kustomization.yaml
   - media-kustomization.yaml
+  - arc-kustomization.yaml


### PR DESCRIPTION
## Overview
Finalizes the migration to the **Mainline ARC** (`gha-runner-scale-set`) by defining it as a Flux Managed service.

## 🧱 Changes
- Added `HelmRepository` for ARC (OCI).
- Created `arc-systems` and `arc-runners` directories with `HelmRelease` and `Kustomization` manifests.
- Integrated ARC syncs into the main Flux `syncs` list.
- Configured `arc-runner-set` to use the optimized runner image and established dependency on `arc-operator`.

## 🚀 Impact
The cluster will now automatically deploy and reconcile the modern ARC infrastructure via Flux.