### PR TITLE
fix(openclaw): grant read-only access to networkpolicies

### DIFF
--- a/home-cluster/openclaw/rbac.yaml
+++ b/home-cluster/openclaw/rbac.yaml
@@ -54,6 +54,9 @@ rules:
 - apiGroups: ["apps"]
   resources: ["deployments", "statefulsets", "daemonsets"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Overview
This PR adds permissions for the `openclaw` ServiceAccount to `get`, `list`, and `watch` NetworkPolicies.

## 🧱 Why
This is critical for Kilo to diagnose connectivity issues (like the current Headlamp 'No Clusters' error) by auditing which ingress/egress rules are active in the cluster.