### PR TITLE
fix(headlamp): health, network policy, and flux plugin

### DIFF
--- a/home-cluster/headlamp/deployment.yaml
+++ b/home-cluster/headlamp/deployment.yaml
@@ -16,38 +16,57 @@ spec:
         app: headlamp
     spec:
       serviceAccountName: headlamp
+      initContainers:
+        - name: install-flux-plugin
+          image: alpine:3.19
+          command:
+            - sh
+            - -c
+            - |
+              apk add --no-cache curl
+              mkdir -p /plugins/flux
+              curl -sL https://github.com/headlamp-k8s/plugins/releases/latest/download/flux-plugin.tar.gz | tar -xz -C /plugins/flux
+          volumeMounts:
+            - name: plugins
+              mountPath: /plugins
       containers:
-      - name: headlamp
-        image: ghcr.io/headlamp-k8s/headlamp:latest
-        args:
-        - -plugins-dir=/headlamp/plugins
-        ports:
-        - containerPort: 4466
-          name: http
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-          limits:
-            cpu: "1"
-            memory: 512Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          runAsNonRoot: true
-          runAsUser: 100
-          runAsGroup: 101
-        volumeMounts:
-        - name: plugins
-          mountPath: /headlamp/plugins
-        - name: kubeconfig
-          mountPath: /etc/kubeconfig
-          readOnly: true
+        - name: headlamp
+          image: ghcr.io/headlamp-k8s/headlamp:latest
+          args:
+            - -plugins-dir=/headlamp/plugins
+          env:
+            - name: KUBECONFIG
+              value: /home/headlamp/.kube/config
+          ports:
+            - containerPort: 4466
+              name: http
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 1
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 2000
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - name: plugins
+              mountPath: /headlamp/plugins
+            - name: kubeconfig
+              mountPath: /home/headlamp/.kube
+              readOnly: true
       volumes:
-      - name: plugins
-        emptyDir: {}
-      - name: kubeconfig
-        secret:
-          secretName: headlamp-kubeconfig
+        - name: plugins
+          emptyDir: {}
+        - name: kubeconfig
+          secret:
+            secretName: headlamp-kubeconfig
+            items:
+              - key: config
+                path: config

--- a/home-cluster/headlamp/deployment.yaml.bak
+++ b/home-cluster/headlamp/deployment.yaml.bak
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: headlamp
+  labels:
+    app: headlamp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: headlamp
+  template:
+    metadata:
+      labels:
+        app: headlamp
+    spec:
+      serviceAccountName: headlamp
+      containers:
+      - name: headlamp
+        image: ghcr.io/headlamp-k8s/headlamp:latest
+        args:
+        - -plugins-dir=/headlamp/plugins
+        ports:
+        - containerPort: 4466
+          name: http
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: "1"
+            memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 100
+          runAsGroup: 101
+        volumeMounts:
+        - name: plugins
+          mountPath: /headlamp/plugins
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig
+          readOnly: true
+      volumes:
+      - name: plugins
+        emptyDir: {}
+      - name: kubeconfig
+        secret:
+          secretName: headlamp-kubeconfig

--- a/home-cluster/headlamp/kustomization.yaml
+++ b/home-cluster/headlamp/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - secret.yaml
   - ingressroute.yaml
   - dnsendpoint.yaml
+  - networkpolicy.yaml

--- a/home-cluster/headlamp/networkpolicy.yaml
+++ b/home-cluster/headlamp/networkpolicy.yaml
@@ -1,0 +1,65 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: headlamp-default-deny
+  namespace: headlamp
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: headlamp-allow-dns
+  namespace: headlamp
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: headlamp-allow-ingress
+  namespace: headlamp
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik
+    ports:
+    - protocol: TCP
+      port: 4466
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: headlamp-allow-kube-api
+  namespace: headlamp
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 10.152.183.1/32
+    ports:
+    - protocol: TCP
+      port: 443


### PR DESCRIPTION
## Overview
Restores Headlamp functionality and enhances it with the Flux plugin.

## 🧱 Changes
- **NetworkPolicy**: Added a restrictive policy for the `headlamp` namespace that explicitly allows egress to the Kubernetes API (10.152.183.1) and DNS, resolving the 'Connection refused' errors.
- **Deployment Fix**: 
    - Corrected the `kubeconfig` mount path to `/home/headlamp/.kube/config`.
    - Added the `KUBECONFIG` environment variable.
- **Flux Plugin**: Added an `initContainer` to automatically fetch and install the Headlamp Flux plugin on startup.