### PR TITLE
feat(arc): increase runner parallelism

### DIFF
--- a/home-cluster/arc-runners/helmrelease.yaml
+++ b/home-cluster/arc-runners/helmrelease.yaml
@@ -24,8 +24,8 @@ spec:
   values:
     githubConfigUrl: "https://github.com/kg6zjl/clusters"
     githubConfigSecret: github-runner-secret
-    minReplicas: 2
-    maxReplicas: 5
+    minReplicas: 3
+    maxReplicas: 10
     controllerServiceAccount:
       name: arc-operator-gha-runner-scale-set-controller
       namespace: arc-systems


### PR DESCRIPTION
## Overview
Increases the available CI runner capacity to speed up job execution times.

## 🧱 Changes
- **minReplicas**: Increased from 2 to **3** (keeps more hot-standby pods ready).
- **maxReplicas**: Increased from 5 to **10** (allows for significant scaling during large PR bursts or parallel workflows).