### PR TITLE
fix(arc): add missing namespace definitions

### DIFF
--- a/home-cluster/arc-runners/kustomization.yaml
+++ b/home-cluster/arc-runners/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - namespace.yaml
   - helmrelease.yaml

--- a/home-cluster/arc-runners/namespace.yaml
+++ b/home-cluster/arc-runners/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: arc-runners

--- a/home-cluster/arc-systems/kustomization.yaml
+++ b/home-cluster/arc-systems/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - namespace.yaml
   - helmrelease.yaml

--- a/home-cluster/arc-systems/namespace.yaml
+++ b/home-cluster/arc-systems/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: arc-systems


### PR DESCRIPTION
Adds `namespace.yaml` to both `arc-systems` and `arc-runners`. This allows Flux to take ownership of these namespaces and proceed with the mainline ARC deployment, which is currently stalled.