### PR TITLE
fix(arc): resolve OCI pull 403 error

### DIFF
--- a/home-cluster/flux-system/arc-helmrepository.yaml
+++ b/home-cluster/flux-system/arc-helmrepository.yaml
@@ -7,3 +7,4 @@ spec:
   interval: 1h
   type: oci
   url: oci://ghcr.io/actions/actions-runner-controller
+  provider: generic


### PR DESCRIPTION
## Overview
Fixes the **403 Forbidden** error that prevented Flux from pulling the ARC Helm charts from GHCR.

## 🧱 Changes
- Updated `actions-runner-controller-mainline` HelmRepository.
- Set `provider: generic` to ensure compatible anonymous pulls from GitHub Container Registry.

This will unblock the deployment of the `arc-operator` and `arc-runner-set`.