### PR TITLE
fix(security): restore cluster-wide Ingress connectivity

### DIFF
--- a/home-cluster/ai-services/dns-egress.yaml
+++ b/home-cluster/ai-services/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/cert-manager/dns-egress.yaml
+++ b/home-cluster/cert-manager/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/cloudflared/dns-egress.yaml
+++ b/home-cluster/cloudflared/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/frigate/dns-egress.yaml
+++ b/home-cluster/frigate/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/home-assistant/dns-egress.yaml
+++ b/home-cluster/home-assistant/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/media/dns-egress.yaml
+++ b/home-cluster/media/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/meshtastic-bot/dns-egress.yaml
+++ b/home-cluster/meshtastic-bot/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/meshtastic/dns-egress.yaml
+++ b/home-cluster/meshtastic/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/monitoring/dns-egress.yaml
+++ b/home-cluster/monitoring/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/mqtt/dns-egress.yaml
+++ b/home-cluster/mqtt/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/netalertx/dns-egress.yaml
+++ b/home-cluster/netalertx/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/oauth2-proxy/dns-egress.yaml
+++ b/home-cluster/oauth2-proxy/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/pihole/dns-egress.yaml
+++ b/home-cluster/pihole/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/plex/dns-egress.yaml
+++ b/home-cluster/plex/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/quotes/dns-egress.yaml
+++ b/home-cluster/quotes/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/registry/dns-egress.yaml
+++ b/home-cluster/registry/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/renovate/dns-egress.yaml
+++ b/home-cluster/renovate/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/speedtest/dns-egress.yaml
+++ b/home-cluster/speedtest/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/traefik/dns-egress.yaml
+++ b/home-cluster/traefik/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik

--- a/home-cluster/vpn/dns-egress.yaml
+++ b/home-cluster/vpn/dns-egress.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - to:
@@ -17,3 +18,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik


### PR DESCRIPTION
## Overview
Restores Ingress connectivity to 20 namespaces that were accidentally locked down by the previous DNS-only NetworkPolicy.

## 🧱 Changes
- Updated `dns-egress.yaml` in all managed namespaces.
- Set `policyTypes: [Ingress, Egress]`.
- Added an **Ingress allow rule** from the `traefik` namespace.
- Preserved the **Egress allow rule** for Port 53 (CoreDNS).

## 🚨 Impact
This will immediately restore access to Home Assistant, Plex, Frigate, and all other UIs while maintaining the security goal of explicit DNS egress.