### PR TITLE
fix: allow auth and pihole namespace ingress to traefik

### DIFF
--- a/home-cluster/flux-system/syncs/kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kustomization.yaml
@@ -23,4 +23,5 @@ resources:
   - renovate-kustomization.yaml
   - ai-services-kustomization.yaml
   - media-kustomization.yaml
+  - monitoring-kustomization.yaml
   - arc-kustomization.yaml

--- a/home-cluster/flux-system/syncs/monitoring-kustomization.yaml
+++ b/home-cluster/flux-system/syncs/monitoring-kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: monitoring
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  path: ./home-cluster/monitoring
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters
+  targetNamespace: monitoring
+  timeout: 2m0s

--- a/home-cluster/traefik/dns-egress.yaml
+++ b/home-cluster/traefik/dns-egress.yaml
@@ -23,3 +23,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: traefik
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: auth
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: pihole


### PR DESCRIPTION
Fixes ingress routing from oauth2-proxy (auth namespace) and pihole to traefik