### PR TITLE
fix(networkpolicy): allow ingress from all namespaces to traefik

### DIFF
--- a/home-cluster/traefik/dns-egress.yaml
+++ b/home-cluster/traefik/dns-egress.yaml
@@ -20,12 +20,4 @@ spec:
       port: 53
   ingress:
   - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: traefik
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: auth
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: pihole
+    - namespaceSelector: {}


### PR DESCRIPTION
Allow ingress from all namespaces to traefik ingress controller