### PR TITLE
fix(networkpolicy): allow ingress and kube-apiserver egress for traefik

### DIFF
--- a/home-cluster/traefik/dns-egress.yaml
+++ b/home-cluster/traefik/dns-egress.yaml
@@ -18,14 +18,13 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: TCP
+      port: 443
   ingress:
   - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: traefik
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: auth
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: pihole
+    - namespaceSelector: {}


### PR DESCRIPTION
Allow traefik to reach kube-apiserver for ingress discovery