### PR TITLE
fix(traefik): allow only DNS and kube-api egress, permit all ingress

### DIFF
--- a/home-cluster/traefik/dns-egress.yaml
+++ b/home-cluster/traefik/dns-egress.yaml
@@ -1,12 +1,11 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: traefik-allow-dns
+  name: traefik-allow-egress
   namespace: traefik
 spec:
   podSelector: {}
   policyTypes:
-  - Ingress
   - Egress
   egress:
   - to:
@@ -25,6 +24,3 @@ spec:
     ports:
     - protocol: TCP
       port: 443
-  ingress:
-  - from:
-    - namespaceSelector: {}


### PR DESCRIPTION
Fixes ingress by only restricting egress, allowing all ingress traffic