### PR TITLE
fix(namespace): add labels for NetworkPolicy matching

### DIFF
--- a/home-cluster/ai-services/namespace.yaml
+++ b/home-cluster/ai-services/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ai-services
+  labels:
+    kubernetes.io/metadata.name: ai-services

--- a/home-cluster/frigate/namespace.yaml
+++ b/home-cluster/frigate/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: frigate
+  labels:
+    kubernetes.io/metadata.name: frigate

--- a/home-cluster/headlamp/namespace.yaml
+++ b/home-cluster/headlamp/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: headlamp
+  labels:
+    kubernetes.io/metadata.name: headlamp

--- a/home-cluster/home-assistant/namespace.yaml
+++ b/home-cluster/home-assistant/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: home-assistant
+  labels:
+    kubernetes.io/metadata.name: home-assistant

--- a/home-cluster/openclaw/namespace.yaml
+++ b/home-cluster/openclaw/namespace.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: openclaw
   labels:
-    app.kubernetes.io/name: openclaw
+    kubernetes.io/metadata.name: openclaw

--- a/home-cluster/traefik/namespace.yaml
+++ b/home-cluster/traefik/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: traefik
+  labels:
+    kubernetes.io/metadata.name: traefik


### PR DESCRIPTION
Fixes Gateway Timeouts by adding 'kubernetes.io/metadata.name' labels to namespaces, allowing NetworkPolicies to properly match Traefik ingress selectors.