### PR TITLE
fix(traefik): allow all egress for hostNetwork backend access

### DIFF
--- a/home-cluster/traefik/dns-egress.yaml
+++ b/home-cluster/traefik/dns-egress.yaml
@@ -1,26 +1,11 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: traefik-allow-egress
+  name: traefik-default-egress
   namespace: traefik
 spec:
   podSelector: {}
   policyTypes:
   - Egress
   egress:
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-    ports:
-    - protocol: UDP
-      port: 53
-    - protocol: TCP
-      port: 53
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-    ports:
-    - protocol: TCP
-      port: 443
+  - {}


### PR DESCRIPTION
Allow traefik to reach hostNetwork backends like home-assistant