### PR TITLE
fix(monitoring): add ingress availability monitoring

### DIFF
--- a/home-cluster/helmfile.yaml
+++ b/home-cluster/helmfile.yaml
@@ -540,7 +540,6 @@ releases:
               prober: http
               http:
                 follow_redirects: true
-                insecure_skip_verify: false
   - name: pihole
     namespace: pihole
     chart: pihole-v6/pihole

--- a/home-cluster/monitoring/dns-egress.yaml
+++ b/home-cluster/monitoring/dns-egress.yaml
@@ -18,8 +18,22 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 80
   ingress:
   - from:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: traefik
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: monitoring


### PR DESCRIPTION
Adds ingress availability monitoring with blackbox-exporter probes and alerts. Updates monitoring network policy to allow external HTTPS.