### PR TITLE
fix(cert-manager): allow HTTPS egress for Let's Encrypt ACME challenges

### DIFF
--- a/home-cluster/cert-manager/network-policy.yaml
+++ b/home-cluster/cert-manager/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: cert-manager-allow-dns
+  name: cert-manager-allow-egress
   namespace: cert-manager
 spec:
   podSelector: {}
@@ -18,6 +18,11 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 443
   ingress:
   - from:
     - namespaceSelector:


### PR DESCRIPTION
Enables cert-manager to reach Let's Encrypt servers for certificate renewal