### PR TITLE
fix: allow HTTPS egress for cloudflared and renovate

### DIFF
--- a/home-cluster/cloudflared/network-policy.yaml
+++ b/home-cluster/cloudflared/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: cloudflared-allow-dns
+  name: cloudflared-allow-egress
   namespace: cloudflared
 spec:
   podSelector: {}
@@ -18,8 +18,11 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 443
   ingress:
   - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: traefik
+    - namespaceSelector: {}

--- a/home-cluster/renovate/network-policy.yaml
+++ b/home-cluster/renovate/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: renovate-allow-dns
+  name: renovate-allow-egress
   namespace: renovate
 spec:
   podSelector: {}
@@ -18,8 +18,13 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 443
   ingress:
   - from:
     - namespaceSelector:
         matchLabels:
-          kubernetes.io/metadata.name: traefik
+          kubernetes.io/metadata.name: kube-system


### PR DESCRIPTION
Enables cloudflared and renovate to reach external APIs