### PR TITLE
fix: allow HTTPS egress for all user namespaces

### DIFF
--- a/home-cluster/ai-services/network-policy.yaml
+++ b/home-cluster/ai-services/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: ai-services-allow-dns
+  name: ai-services-allow-egress
   namespace: ai-services
 spec:
   podSelector: {}
@@ -18,6 +18,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector:

--- a/home-cluster/frigate/network-policy.yaml
+++ b/home-cluster/frigate/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: frigate-allow-dns
+  name: frigate-allow-egress
   namespace: frigate
 spec:
   podSelector: {}
@@ -18,6 +18,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector:

--- a/home-cluster/home-assistant/network-policy.yaml
+++ b/home-cluster/home-assistant/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: home-assistant-allow-dns
+  name: home-assistant-allow-egress
   namespace: home-assistant
 spec:
   podSelector: {}
@@ -18,6 +18,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector:

--- a/home-cluster/media/network-policy.yaml
+++ b/home-cluster/media/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: media-allow-dns
+  name: media-allow-egress
   namespace: media
 spec:
   podSelector: {}
@@ -18,6 +18,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector:

--- a/home-cluster/meshtastic-bot/network-policy.yaml
+++ b/home-cluster/meshtastic-bot/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: meshtastic-bot-allow-dns
+  name: meshtastic-bot-allow-egress
   namespace: meshtastic-bot
 spec:
   podSelector: {}
@@ -18,6 +18,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector:

--- a/home-cluster/meshtastic/network-policy.yaml
+++ b/home-cluster/meshtastic/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: meshtastic-allow-dns
+  name: meshtastic-allow-egress
   namespace: meshtastic
 spec:
   podSelector: {}
@@ -18,6 +18,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector:

--- a/home-cluster/mqtt/network-policy.yaml
+++ b/home-cluster/mqtt/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: mqtt-allow-dns
+  name: mqtt-allow-egress
   namespace: mqtt
 spec:
   podSelector: {}
@@ -18,6 +18,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector:

--- a/home-cluster/netalertx/network-policy.yaml
+++ b/home-cluster/netalertx/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: netalertx-allow-dns
+  name: netalertx-allow-egress
   namespace: netalertx
 spec:
   podSelector: {}
@@ -18,6 +18,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector:

--- a/home-cluster/oauth2-proxy/network-policy.yaml
+++ b/home-cluster/oauth2-proxy/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: oauth2-proxy-allow-dns
+  name: oauth2-proxy-allow-egress
   namespace: oauth2-proxy
 spec:
   podSelector: {}
@@ -18,6 +18,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector:

--- a/home-cluster/pihole/network-policy.yaml
+++ b/home-cluster/pihole/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: pihole-allow-dns
+  name: pihole-allow-egress
   namespace: pihole
 spec:
   podSelector: {}
@@ -18,8 +18,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: traefik
+    - namespaceSelector: {}

--- a/home-cluster/plex/network-policy.yaml
+++ b/home-cluster/plex/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: plex-allow-dns
+  name: plex-allow-egress
   namespace: plex
 spec:
   podSelector: {}
@@ -18,6 +18,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector:

--- a/home-cluster/quotes/network-policy.yaml
+++ b/home-cluster/quotes/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: quotes-allow-dns
+  name: quotes-allow-egress
   namespace: quotes
 spec:
   podSelector: {}
@@ -18,6 +18,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector:

--- a/home-cluster/registry/network-policy.yaml
+++ b/home-cluster/registry/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: registry-allow-dns
+  name: registry-allow-egress
   namespace: registry
 spec:
   podSelector: {}
@@ -18,8 +18,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: traefik
+    - namespaceSelector: {}

--- a/home-cluster/speedtest/network-policy.yaml
+++ b/home-cluster/speedtest/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: speedtest-allow-dns
+  name: speedtest-allow-egress
   namespace: speedtest
 spec:
   podSelector: {}
@@ -18,6 +18,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector:

--- a/home-cluster/vpn/network-policy.yaml
+++ b/home-cluster/vpn/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: vpn-allow-dns
+  name: vpn-allow-egress
   namespace: vpn
 spec:
   podSelector: {}
@@ -18,8 +18,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: traefik
+    - namespaceSelector: {}


### PR DESCRIPTION
Allow all pods to reach external HTTPS endpoints.

This enables:
- Home Assistant, AI services, Frigate to call external APIs
- Cert-manager to reach Let's Encrypt
- Cloudflared, Renovate to reach external APIs
- Plex, Jellyfin, Speedtest to reach external services
- MQTT, Meshtastic to reach external brokers

Updated network policies for:
- ai-services
- frigate
- home-assistant
- media
- meshtastic
- meshtastic-bot
- mqtt
- netalertx
- oauth2-proxy
- pihole
- plex
- quotes
- registry
- speedtest
- vpn