### PR TITLE
fix(GHA): improve helm rollback and sync retry logic

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -31,14 +31,26 @@ jobs:
       - name: Rollback pending releases
         run: |
           export PATH="/opt/tools/bin:/opt/tools:$PATH"
-          helm list -A --pending 2>/dev/null | awk 'NR>1 {print $1, $2}' | \
-            while read -r release namespace; do
-              echo "Attempting to fix pending release: $release in $namespace"
-              helm rollback "$release" -n "$namespace" 2>/dev/null && echo "Rolled back: $release" && continue
-              echo "Rollback failed, attempting uninstall: $release in $namespace"
-              helm uninstall "$release" -n "$namespace" 2>/dev/null && echo "Uninstalled: $release" && continue
-              echo "Warning: Could not fix pending release $release in $namespace"
+          echo "Checking for pending helm releases..."
+          for i in {1..5}; do
+            PENDING=$(helm list -A --pending 2>/dev/null | awk 'NR>1 {print $1, $2}')
+            if [ -z "$PENDING" ]; then
+              echo "No pending releases found"
+              break
+            fi
+            echo "Attempt $i: Found pending releases:"
+            echo "$PENDING"
+            echo "$PENDING" | while read -r release namespace; do
+              echo "Processing: $release in $namespace"
+              helm rollback "$release" -n "$namespace" 2>&1 && echo "Rolled back: $release" && continue
+              echo "Rollback failed for $release, retrying in 5s..."
+              sleep 5
+              helm rollback "$release" -n "$namespace" 2>&1 && echo "Rolled back: $release" && continue
+              echo "Rollback failed again, uninstalling: $release"
+              helm uninstall "$release" -n "$namespace" 2>&1 && echo "Uninstalled: $release"
             done
+            [ $i -lt 5 ] && sleep 10
+          done
 
       - name: Delete stale Flux CRDs
         run: |
@@ -59,5 +71,15 @@ jobs:
           cd home-cluster
           helmfile repos
           helmfile deps
-          helmfile sync
+          echo "Running helmfile sync with retry..."
+          for i in {1..3}; do
+            echo "Attempt $i of 3..."
+            if helmfile sync 2>&1; then
+              echo "helmfile sync succeeded"
+              break
+            fi
+            echo "helmfile sync failed, retrying in 30s..."
+            sleep 30
+          done
+          echo "Applying kustomize manifests..."
           kubectl apply -k . --server-side --force-conflicts


### PR DESCRIPTION
Fixes the Apply to Cluster workflow:

- Add retry loop for pending helm releases (up to 5 attempts)
- Add retry logic for helmfile sync (up to 3 attempts)
- Better error logging for debugging failures

This should handle stuck helm releases and transient cert-manager webhook timeouts.