### PR TITLE
fix(github-runners): add network policy for HTTPS egress

### DIFF
--- a/home-cluster/github-runners/kustomization.yaml
+++ b/home-cluster/github-runners/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - external-secrets-namespace.yaml
   - external-secrets-store.yaml
   - external-secrets.yaml
+  - network-policy.yaml

--- a/home-cluster/github-runners/network-policy.yaml
+++ b/home-cluster/github-runners/network-policy.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: github-runners-allow-egress
+  namespace: github-runners
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system


### PR DESCRIPTION
Allow GitHub runners to reach external services (GitHub API, Docker Hub, OCI registries)