### PR TITLE
fix: add Flux syncs and network policies for metallb, caddy, github-runners

### DIFF
--- a/home-cluster/caddy-system/kustomization.yaml
+++ b/home-cluster/caddy-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - network-policy.yaml

--- a/home-cluster/caddy-system/namespace.yaml
+++ b/home-cluster/caddy-system/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: caddy-system
+  labels:
+    kubernetes.io/metadata.name: caddy-system

--- a/home-cluster/caddy-system/network-policy.yaml
+++ b/home-cluster/caddy-system/network-policy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: caddy-allow-egress
+  namespace: caddy-system
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector: {}

--- a/home-cluster/flux-system/syncs/caddy-system-kustomization.yaml
+++ b/home-cluster/flux-system/syncs/caddy-system-kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: caddy-system
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  path: ./home-cluster/caddy-system
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters
+  targetNamespace: caddy-system
+  timeout: 2m0s

--- a/home-cluster/flux-system/syncs/github-runners-kustomization.yaml
+++ b/home-cluster/flux-system/syncs/github-runners-kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: github-runners
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  path: ./home-cluster/github-runners
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters
+  targetNamespace: github-runners
+  timeout: 2m0s

--- a/home-cluster/flux-system/syncs/kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kustomization.yaml
@@ -27,4 +27,7 @@ resources:
   - external-secrets-kustomization.yaml
   - clustersecret-kustomization.yaml
   - gpu-operator-kustomization.yaml
+  - metallb-system-kustomization.yaml
+  - caddy-system-kustomization.yaml
+  - github-runners-kustomization.yaml
   - arc-kustomization.yaml

--- a/home-cluster/flux-system/syncs/metallb-system-kustomization.yaml
+++ b/home-cluster/flux-system/syncs/metallb-system-kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: metallb-system
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  path: ./home-cluster/metallb-system
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters
+  targetNamespace: metallb-system
+  timeout: 2m0s

--- a/home-cluster/metallb-system/kustomization.yaml
+++ b/home-cluster/metallb-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - network-policy.yaml

--- a/home-cluster/metallb-system/namespace.yaml
+++ b/home-cluster/metallb-system/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+  labels:
+    kubernetes.io/metadata.name: metallb-system

--- a/home-cluster/metallb-system/network-policy.yaml
+++ b/home-cluster/metallb-system/network-policy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: metallb-allow-egress
+  namespace: metallb-system
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector: {}


### PR DESCRIPTION
Fixes missing Flux syncs and network policies:

- metallb-system: BGP speakers need HTTPS egress
- caddy-system: reverse proxy needs HTTPS egress
- github-runners: Was missing from Flux syncs