### PR TITLE
fix: Restore Ollama/Comfy and remove PiGallery

### DIFF
--- a/home-cluster/ai-services/kustomization.yaml
+++ b/home-cluster/ai-services/kustomization.yaml
@@ -17,11 +17,7 @@ resources:
   - middleware-comfy.yaml
   - ingressroute-comfy.yaml
   - dnsendpoint-comfy.yaml
-  - pigallery2.yaml
-  - ingressroute-pigallery2.yaml
-  - dnsendpoint-pigallery2.yaml
   - external-secrets.yaml
-  - external-secrets-pigallery2.yaml
 
 patches:
   - target:
@@ -29,15 +25,6 @@ patches:
       version: v1alpha1
       kind: DNSEndpoint
       name: chat
-    patch: |-
-      - op: replace
-        path: /metadata/namespace
-        value: kube-system
-  - target:
-      group: externaldns.k8s.io
-      version: v1alpha1
-      kind: DNSEndpoint
-      name: pigallery2
     patch: |-
       - op: replace
         path: /metadata/namespace

--- a/home-cluster/flux-system/syncs/ai-services-kustomization.yaml
+++ b/home-cluster/flux-system/syncs/ai-services-kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ai-services
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: ./home-cluster/ai-services
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters
+  wait: true

--- a/home-cluster/flux-system/syncs/kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - vpn-kustomization.yaml
   - home-assistant-kustomization.yaml
   - renovate-kustomization.yaml
+  - ai-services-kustomization.yaml
   - media-kustomization.yaml
   - monitoring-kustomization.yaml
   - spegel-kustomization.yaml


### PR DESCRIPTION
Corrects previous over-eager deletions. Restores Ollama and Comfy while specifically removing PiGallery2 from the manifests.