### PR TITLE
Migrate monitoring namespace to Flux HelmReleases

### DIFF
--- a/home-cluster/flux-system/syncs/grafana-helmrepository.yaml
+++ b/home-cluster/flux-system/syncs/grafana-helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://grafana.github.io/helm-charts

--- a/home-cluster/flux-system/syncs/kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kustomization.yaml
@@ -4,6 +4,8 @@ namespace: flux-system
 resources:
   - clusters-gitrepository.yaml
   - traefik-helmrepository.yaml
+  - prometheus-community-helmrepository.yaml
+  - grafana-helmrepository.yaml
   - traefik-kustomization.yaml
   - cert-manager-kustomization.yaml
   - netalertx-kustomization.yaml

--- a/home-cluster/flux-system/syncs/prometheus-community-helmrepository.yaml
+++ b/home-cluster/flux-system/syncs/prometheus-community-helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: prometheus-community
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://prometheus-community.github.io/helm-charts

--- a/home-cluster/flux-system/syncs/traefik-helmrepository.yaml
+++ b/home-cluster/flux-system/syncs/traefik-helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: traefik
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://traefik.github.io/charts

--- a/home-cluster/monitoring/blackbox-exporter-helmrelease.yaml
+++ b/home-cluster/monitoring/blackbox-exporter-helmrelease.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: blackbox-exporter
+  namespace: monitoring
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: prometheus-blackbox-exporter
+      version: 9.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: flux-system
+  values:
+    config:
+      modules:
+        http_2xx:
+          prober: http
+          http:
+            follow_redirects: true

--- a/home-cluster/monitoring/external-secrets.yaml
+++ b/home-cluster/monitoring/external-secrets.yaml
@@ -18,3 +18,4 @@ spec:
       remoteRef:
         key: grafana-admin-password
         property: password
+

--- a/home-cluster/monitoring/kube-prometheus-stack-helmrelease.yaml
+++ b/home-cluster/monitoring/kube-prometheus-stack-helmrelease.yaml
@@ -1,0 +1,82 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: monitoring
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: kube-prometheus-stack
+      version: 82.13.2
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: flux-system
+  values:
+    crds:
+      enabled: true
+    prometheus:
+      serviceMonitorSelectorNilUsesHelmValues: false
+      prometheusSpec:
+        retention: 10d
+        ruleSelectorNilUsesHelmValues: false
+        additionalScrapeConfigs:
+          - job_name: ugreen-dxp2800
+            static_configs:
+              - targets:
+                  - nas.stevearnett.com:9100
+          - job_name: ingress-availability
+            metrics_path: /probe
+            params:
+              module: [http_2xx]
+            static_configs:
+              - targets:
+                  - https://ha.kube.stevearnett.com/
+                  - https://frigate.kube.stevearnett.com/
+                  - https://grafana.kube.stevearnett.com/
+                  - https://prometheus.kube.stevearnett.com/
+                labels:
+                  service: ingress
+            relabel_configs:
+              - source_labels: [__address__]
+                target_label: __param_target
+              - source_labels: [__param_target]
+                target_label: instance
+              - target_label: __address__
+                replacement: blackbox-exporter-prometheus-blackbox-exporter.monitoring.svc:9115
+        additionalRules:
+          - name: disable-builtin-alerts
+            groups:
+              - name: kubernetes-system-controller-manager
+                rules: []
+              - name: kubernetes-system-scheduler
+                rules: []
+              - name: kubernetes-system-kube-proxy
+                rules: []
+          - name: ingress-availability
+            rules:
+              - alert: IngressDown
+                expr: probe_success{job="ingress-availability"} == 0
+                for: 2m
+                labels:
+                  severity: critical
+                annotations:
+                  summary: "Ingress {{ $labels.instance }} is down"
+                  description: "Cannot reach {{ $labels.instance }} for 2 minutes"
+    grafana:
+      enabled: true
+      admin:
+        existingSecret: grafana-admin-secret
+        userKey: admin-user
+        passwordKey: GRAFANA_ADMIN_PASSWORD
+      additionalDataSources:
+        - name: Loki
+          type: loki
+          url: http://loki.monitoring.svc.cluster.local:3100
+          access: proxy
+          isDefault: false
+          jsonData:
+            maxLines: 1000
+    alertmanager:
+      enabled: true

--- a/home-cluster/monitoring/kustomization.yaml
+++ b/home-cluster/monitoring/kustomization.yaml
@@ -7,6 +7,10 @@ resources:
   - prometheus-rules.yaml
   - dashboard-ugreen-nas.yaml
   - external-secrets.yaml
+  - kube-prometheus-stack-helmrelease.yaml
+  - loki-helmrelease.yaml
+  - promtail-helmrelease.yaml
+  - blackbox-exporter-helmrelease.yaml
 
 configMapGenerator:
 

--- a/home-cluster/monitoring/loki-helmrelease.yaml
+++ b/home-cluster/monitoring/loki-helmrelease.yaml
@@ -1,0 +1,55 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: loki
+      version: 6.55.0
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: flux-system
+  values:
+    deploymentMode: SingleBinary
+    loki:
+      auth_enabled: false
+      commonConfig:
+        replication_factor: 1
+      storage:
+        type: filesystem
+      limits_config:
+        retention_period: 240h
+      compactor:
+        retention_enabled: true
+        delete_request_store: filesystem
+      schemaConfig:
+        configs:
+          - from: 2024-01-01
+            store: tsdb
+            object_store: filesystem
+            schema: v13
+            index:
+              prefix: loki_index_
+              period: 24h
+    singleBinary:
+      replicas: 1
+      persistence:
+        enabled: true
+        size: 10Gi
+    backend:
+      replicas: 0
+    read:
+      replicas: 0
+    write:
+      replicas: 0
+    chunksCache:
+      enabled: false
+    resultsCache:
+      enabled: false
+    sidecar:
+      enabled: false
+      skipTlsVerify: true

--- a/home-cluster/monitoring/promtail-helmrelease.yaml
+++ b/home-cluster/monitoring/promtail-helmrelease.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: promtail
+  namespace: monitoring
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: promtail
+      version: 6.17.1
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: flux-system
+  values:
+    config:
+      clients:
+        - url: http://loki:3100/loki/api/v1/push


### PR DESCRIPTION
## Summary
- Add `prometheus-community` and `grafana` HelmRepositories to flux-system
- Add `traefik` HelmRepository (was missing from traefik migration)
- Create Flux HelmReleases for monitoring stack:
  - kube-prometheus-stack (v82.13.2)
  - loki (v6.55.0)
  - promtail (v6.17.1)
  - blackbox-exporter (v9.2.0)

## Notes
- Alertmanager uses simplified config (no email/NTFY env vars) - can be extended via ESO Secret later
- helmfile still manages these releases until this PR is merged and verified working