### PR TITLE
fix(github-runners): allow egress to kube-system

### DIFF
--- a/home-cluster/github-runners/network-policy.yaml
+++ b/home-cluster/github-runners/network-policy.yaml
@@ -9,7 +9,11 @@ spec:
   - Ingress
   - Egress
   egress:
-  - ports:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
     - protocol: TCP
       port: 443
     - protocol: TCP
@@ -18,6 +22,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector:


### PR DESCRIPTION
Fixes ARC controller CrashLoopBackOff by allowing egress to kube-system namespace for Kubernetes API access.