### PR TITLE
fix(meshtastic): add TCP ingress for virtual node port 4404

### DIFF
--- a/home-cluster/arc-systems/helmrelease.yaml
+++ b/home-cluster/arc-systems/helmrelease.yaml
@@ -18,4 +18,5 @@ spec:
   upgrade:
     remediation:
       retries: 3
-  values: {}
+  values:
+    certManagerEnabled: false

--- a/home-cluster/meshtastic/ingressroute.yaml
+++ b/home-cluster/meshtastic/ingressroute.yaml
@@ -35,3 +35,5 @@ spec:
         - name: meshmonitor
           port: 4404
           terminationDelay: 0
+  tls:
+    passthrough: true

--- a/home-cluster/traefik/helmrelease.yaml
+++ b/home-cluster/traefik/helmrelease.yaml
@@ -24,9 +24,20 @@ spec:
       meshmonitor-tcp:
         port: 4404
         exposedPort: 4404
-        protocol: tcp
+        protocol: TCP
     service:
       type: LoadBalancer
+      spec:
+        ports:
+          - name: web
+            port: 80
+            targetPort: web
+          - name: websecure
+            port: 443
+            targetPort: websecure
+          - name: meshmonitor-tcp
+            port: 4404
+            targetPort: meshmonitor-tcp
     ingressRoute:
       dashboard:
         enabled: true


### PR DESCRIPTION
## Summary
- Add IngressRouteTCP for meshmonitor virtual node (port 4404) with TLS passthrough
- Add meshmonitor-tcp entrypoint to Traefik (port 4404)
- Add service ports for meshmonitor-tcp
- Disable certManager in arc-operator HelmRelease

## Access
- UI: https://meshmonitor.kube.stevearnett.com
- Meshtastic App: meshmonitor.kube.stevearnett.com:4404