### PR TITLE
fix(meshtastic): remove TLS from IngressRouteTCP for raw TCP

### DIFF
--- a/home-cluster/meshtastic/ingressroute.yaml
+++ b/home-cluster/meshtastic/ingressroute.yaml
@@ -30,10 +30,8 @@ spec:
   entryPoints:
     - meshmonitor-tcp
   routes:
-    - match: HostSNI(`meshmonitor.kube.stevearnett.com`)
+    - match: HostSNI(`*`)
       services:
         - name: meshmonitor
           port: 4404
           terminationDelay: 0
-  tls:
-    passthrough: true


### PR DESCRIPTION
Remove TLS passthrough from IngressRouteTCP - the app uses raw TCP with protobuf, not TLS.