### PR TITLE
fix(external-secrets): allow egress to default namespace for API server

### DIFF
--- a/home-cluster/external-secrets/network-policy.yaml
+++ b/home-cluster/external-secrets/network-policy.yaml
@@ -21,6 +21,13 @@ spec:
     - protocol: TCP
       port: 443
   - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+  - to:
     - namespaceSelector: {}
   ingress:
   - from:


### PR DESCRIPTION
## Summary
- Add egress rule for `default` namespace on port 443
- ESO controller needs to reach K8s API server which runs in `default` namespace
- This fixes the timeout error: `dial tcp 10.152.183.1:443: i/o timeout`

## Root Cause
NetworkPolicy had egress to `kube-system` but API server endpoints are in `default` namespace. The catch-all egress `{}` was not working reliably with Calico CNI.