### PR TITLE
fix(github-runners): allow egress to default namespace for API server

### DIFF
--- a/home-cluster/github-runners/network-policy.yaml
+++ b/home-cluster/github-runners/network-policy.yaml
@@ -9,7 +9,26 @@ spec:
   - Ingress
   - Egress
   egress:
-  - {}
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector:


### PR DESCRIPTION
## Summary
- Add explicit egress rules for  and  namespaces
- Calico pods need to reach Kubernetes API server to set up networking
- This fixes the sandbox creation failures

## Error Fixed


## Root Cause
The catch-all egress rule  was not working reliably with Calico CNI for pods in github-runners namespace.