### PR TITLE
fix(github-runners): use custom optimized runner image

### DIFF
--- a/home-cluster/github-runners/runner-deployment.yaml
+++ b/home-cluster/github-runners/runner-deployment.yaml
@@ -11,3 +11,4 @@ spec:
       labels:
         - self-hosted
         - kubernetes
+      image: registry.kube.stevearnett.com/github-runner-optimized:latest


### PR DESCRIPTION
## Summary
- Add custom runner image to RunnerDeployment
- The default summerwind/actions-runner image is missing CI tools (kubectl, gitleaks)

## CI Failures Fixed
- Validate: kubectl: command not found
- Secret Scan: /opt/tools/gitleaks: No such file or directory