### PR TITLE
fix(external-secrets): add explicit API server IP egress rule

### DIFF
--- a/home-cluster/external-secrets/network-policy.yaml
+++ b/home-cluster/external-secrets/network-policy.yaml
@@ -28,6 +28,12 @@ spec:
     - protocol: TCP
       port: 443
   - to:
+    - ipBlock:
+        cidr: 10.152.183.1/32
+    ports:
+    - protocol: TCP
+      port: 443
+  - to:
     - namespaceSelector: {}
   ingress:
   - from:


### PR DESCRIPTION
## Summary
The ESO controller is failing with "dial tcp 10.152.183.1:443: i/o timeout" despite having a network policy allowing egress to the `default` namespace.

This adds an explicit egress rule for the API server IP (10.152.183.1/32) to ensure Calico correctly allows traffic to the Kubernetes API server.