### PR TITLE
fix(external-secrets): make network policy more permissive

### DIFF
--- a/home-cluster/external-secrets/network-policy.yaml
+++ b/home-cluster/external-secrets/network-policy.yaml
@@ -10,31 +10,23 @@ spec:
   - Egress
   egress:
   - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-    ports:
-    - protocol: UDP
-      port: 53
-    - protocol: TCP
-      port: 53
-    - protocol: TCP
-      port: 443
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: default
-    ports:
-    - protocol: TCP
-      port: 443
+    - namespaceSelector: {}
+      podSelector: {}
   - to:
     - ipBlock:
-        cidr: 10.152.183.1/32
+        cidr: 10.0.0.0/8
+    ports:
+    - protocol: TCP
+      ports:
+      - 443
+      - 80
+      - 53
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
     ports:
     - protocol: TCP
       port: 443
-  - to:
-    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector: {}


### PR DESCRIPTION
## Summary

The ESO controller keeps crashing with "dial tcp 10.152.183.1:443: i/o timeout" despite having namespace-based egress rules. This makes the network policy more permissive to test if the issue is with the policy rules.

Changes:
- Allow all traffic within the cluster (all namespaces + pods)
- Allow TCP ports 443, 80, 53 to 10.0.0.0/8
- Allow HTTPS to all external destinations

Once we confirm this fixes the issue, we can narrow down to the minimal required rules.