### PR TITLE
fix(arc-systems): configure GitHub token for ARC controller

### DIFF
--- a/home-cluster/arc-systems/helmrelease.yaml
+++ b/home-cluster/arc-systems/helmrelease.yaml
@@ -20,3 +20,6 @@ spec:
       retries: 3
   values:
     certManagerEnabled: false
+    githubTokenSecretRef:
+      name: controller-manager
+      key: github_token


### PR DESCRIPTION
Add githubTokenSecretRef to connect the ARC controller to GitHub for runner registration.