### PR TITLE
fix(runners): use working scoped token

### DIFF
--- a/home-cluster/github-runners/external-secrets.yaml
+++ b/home-cluster/github-runners/external-secrets.yaml
@@ -16,7 +16,7 @@ spec:
   data:
     - secretKey: github_token
       remoteRef:
-        key: github-runner-token
+        key: github-cluster-scoped-token
         property: password
 
 ---


### PR DESCRIPTION
The currently configured runner token is failing authentication. Moving back to the working scoped token to restore CI.