### PR TITLE
fix(github-runners): allow all egress and sync token to arc-systems

### DIFF
--- a/home-cluster/arc-systems/external-secrets.yaml
+++ b/home-cluster/arc-systems/external-secrets.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: controller-manager-secret
+  namespace: arc-systems
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+  target:
+    name: controller-manager
+  data:
+    - secretKey: github_token
+      remoteRef:
+        key: github-runner-token
+        property: password

--- a/home-cluster/arc-systems/kustomization.yaml
+++ b/home-cluster/arc-systems/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespace.yaml
   - helmrelease.yaml
   - network-policy.yaml
+  - external-secrets.yaml

--- a/home-cluster/github-runners/network-policy.yaml
+++ b/home-cluster/github-runners/network-policy.yaml
@@ -6,29 +6,16 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
-  - Ingress
   - Egress
   egress:
-  - to:
+  - ports:
+    - protocol: TCP
+      port: 443
+    to:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: kube-system
-    ports:
-    - protocol: UDP
-      port: 53
-    - protocol: TCP
-      port: 53
-    - protocol: TCP
-      port: 443
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: default
-    ports:
-    - protocol: TCP
-      port: 443
-  - to:
-    - namespaceSelector: {}
+  - {}
   ingress:
   - from:
     - namespaceSelector:


### PR DESCRIPTION
## Summary
- Allow all egress from github-runners namespace (fixes runners unable to reach GitHub)
- Add ExternalSecret to arc-systems namespace to sync GitHub token for ARC controller
- Remove Ingress policy type (not needed for runners)

## Testing
Runners now successfully register with GitHub and can run CI jobs.