### PR TITLE
fix(runners): move tools to /usr/local/bin for global accessibility

### DIFF
--- a/home-cluster/github-runners/Dockerfile.optimized
+++ b/home-cluster/github-runners/Dockerfile.optimized
@@ -19,40 +19,33 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Create a tools directory
-RUN mkdir -p /opt/tools/bin
-ENV PATH="/opt/tools/bin:${PATH}"
-
 # Install kubectl
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
-    chmod +x kubectl && mv kubectl /opt/tools/bin/
+    chmod +x kubectl && mv kubectl /usr/local/bin/
 
 # Install Helm
 RUN curl -fsSL https://get.helm.sh/helm-v3.16.4-linux-amd64.tar.gz | tar -zxf - -C /tmp && \
-    mv /tmp/linux-amd64/helm /opt/tools/bin/ && rm -rf /tmp/linux-amd64
+    mv /tmp/linux-amd64/helm /usr/local/bin/ && rm -rf /tmp/linux-amd64
 
 # Install Kustomize
 RUN curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash && \
-    mv kustomize /opt/tools/bin/
+    mv kustomize /usr/local/bin/
 
 # Install GitHub CLI (gh)
 RUN curl -fsSL https://github.com/cli/cli/releases/download/v2.47.0/gh_2.47.0_linux_amd64.tar.gz | tar -zxf - -C /tmp && \
-    mv /tmp/gh_2.47.0_linux_amd64/bin/gh /opt/tools/bin/ && rm -rf /tmp/gh*
+    mv /tmp/gh_2.47.0_linux_amd64/bin/gh /usr/local/bin/ && rm -rf /tmp/gh*
 
 # Install Gitleaks
-RUN curl -fsSL https://github.com/gitleaks/gitleaks/releases/download/v8.18.2/gitleaks_8.18.2_linux_x64.tar.gz | tar -zxf - -C /opt/tools/bin/ gitleaks
+RUN curl -fsSL https://github.com/gitleaks/gitleaks/releases/download/v8.18.2/gitleaks_8.18.2_linux_x64.tar.gz | tar -zxf - -C /usr/local/bin/ gitleaks
 
 # Install yq
-RUN curl -L "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /opt/tools/bin/yq && \
-    chmod +x /opt/tools/bin/yq
+RUN curl -L "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /usr/local/bin/yq && \
+    chmod +x /usr/local/bin/yq
 
 # Install Yamllint via pip (system-wide for easier access)
 RUN pip3 install --no-cache-dir --break-system-packages yamllint
 
 # Add Trufflehog (binary install)
-RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /opt/tools/bin
-
-# Set permissions for the runner user
-RUN chown -R runner:runner /opt/tools
+RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
 
 USER runner


### PR DESCRIPTION
Moving binaries to /usr/local/bin as the previous /opt/tools/bin approach was causing path resolution issues in some CI steps.