### PR TITLE
fix(runners): map registry secrets to build workflow

### DIFF
--- a/.github/workflows/runner-image.yaml
+++ b/.github/workflows/runner-image.yaml
@@ -23,6 +23,9 @@ jobs:
       - name: Configure Docker auth
         run: |
           echo "$REGISTRY_PASSWORD" | docker login ${{ env.REGISTRY }} -u "$REGISTRY_USERNAME" --password-stdin
+        env:
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
The docker login step was failing because the registry secrets weren't being injected into the step's environment.