### PR TITLE
fix(runners): grant RBAC to default service account

### DIFF
--- a/home-cluster/github-runners/rbac.yaml
+++ b/home-cluster/github-runners/rbac.yaml
@@ -27,3 +27,6 @@ subjects:
   - kind: ServiceAccount
     name: github-runner
     namespace: github-runners
+  - kind: ServiceAccount
+    name: default
+    namespace: github-runners


### PR DESCRIPTION
The build pods are using the default service account, which lacks registry secret access. This grants it the necessary permissions.