### PR TITLE
fix(runners): extremely robust helm download with manual loop

### DIFF
--- a/home-cluster/github-runners/Dockerfile.optimized
+++ b/home-cluster/github-runners/Dockerfile.optimized
@@ -24,8 +24,12 @@ RUN curl -LO --retry 5 --retry-delay 5 "https://dl.k8s.io/release/$(curl -L -s h
     chmod +x kubectl && mv kubectl /usr/local/bin/
 
 # Install Helm
-RUN curl -fsSL --retry 5 --retry-delay 5 https://get.helm.sh/helm-v3.16.4-linux-amd64.tar.gz | tar -zxf - -C /tmp && \
-    mv /tmp/linux-amd64/helm /usr/local/bin/ && rm -rf /tmp/linux-amd64
+RUN for i in {1..10}; do \
+    curl -fsSL https://get.helm.sh/helm-v3.16.4-linux-amd64.tar.gz -o /tmp/helm.tar.gz && break || \
+    sleep 10; \
+    done && \
+    tar -zxf /tmp/helm.tar.gz -C /tmp && \
+    mv /tmp/linux-amd64/helm /usr/local/bin/ && rm -rf /tmp/linux-amd64 /tmp/helm.tar.gz
 
 # Install Kustomize
 RUN curl -s --retry 5 --retry-delay 5 "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash && \


### PR DESCRIPTION
Existing curl retries were failing due to persistent connection resets. Moving to a manual 10-retry loop with file buffering for Helm.