### PR TITLE
fix(runners): allow internet and cluster API egress

### DIFF
--- a/home-cluster/github-runners/network-policy.yaml
+++ b/home-cluster/github-runners/network-policy.yaml
@@ -8,14 +8,32 @@ spec:
   policyTypes:
   - Egress
   egress:
-  - ports:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
     - protocol: TCP
       port: 443
-    to:
+    - protocol: TCP
+      port: 80
+  - to:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: kube-system
-  - {}
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector:


### PR DESCRIPTION
The existing policy was too restrictive and blocked the runners from downloading Helm and other tools during image builds.