### PR TITLE
fix(runners): explicitly allow egress to cluster API IP

### DIFF
--- a/home-cluster/github-runners/network-policy.yaml
+++ b/home-cluster/github-runners/network-policy.yaml
@@ -17,6 +17,12 @@ spec:
     - protocol: TCP
       port: 80
   - to:
+    - ipBlock:
+        cidr: 10.152.183.1/32
+    ports:
+    - protocol: TCP
+      port: 443
+  - to:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: kube-system


### PR DESCRIPTION
The build is timing out reaching the API server (10.152.183.1). Explicitly adding the IP block to the allowed egress to unblock secret retrieval.