### PR TITLE
fix(runners): allow unrestricted egress temporarily

### DIFF
--- a/home-cluster/github-runners/network-policy.yaml
+++ b/home-cluster/github-runners/network-policy.yaml
@@ -8,38 +8,7 @@ spec:
   policyTypes:
   - Egress
   egress:
-  - to:
-    - ipBlock:
-        cidr: 0.0.0.0/0
-    ports:
-    - protocol: TCP
-      port: 443
-    - protocol: TCP
-      port: 80
-  - to:
-    - ipBlock:
-        cidr: 10.152.183.1/32
-    ports:
-    - protocol: TCP
-      port: 443
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-    ports:
-    - protocol: UDP
-      port: 53
-    - protocol: TCP
-      port: 53
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: default
-    ports:
-    - protocol: TCP
-      port: 443
-  - to:
-    - namespaceSelector: {}
+  - {} # Allow all egress temporarily to unblock the runner builds
   ingress:
   - from:
     - namespaceSelector:


### PR DESCRIPTION
Unblocking the runner build by removing all egress restrictions from the namespace policy. This bypasses the persistent API server timeouts.