### PR TITLE
chore: scale runners back to 2

### DIFF
--- a/home-cluster/github-runners/runner-deployment.yaml
+++ b/home-cluster/github-runners/runner-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: github-runner
   namespace: github-runners
 spec:
-  replicas: 0
+  replicas: 2
   template:
     spec:
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
Scales github-runners back to 2 now that the legacy state is cleared.