### PR TITLE
feat(openclaw): extend scout RBAC for logs and deployment patching

### DIFF
--- a/home-cluster/openclaw/rbac.yaml
+++ b/home-cluster/openclaw/rbac.yaml
@@ -47,16 +47,19 @@ rules:
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["pods/log"]
-  verbs: ["get"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["delete"]
 - apiGroups: ["apps"]
   resources: ["deployments", "statefulsets", "daemonsets"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "patch"]
 - apiGroups: ["networking.k8s.io"]
   resources: ["networkpolicies"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["actions.summerwind.dev"]
+  resources: ["runners", "runnerreplicasets", "runnerdeployments"]
+  verbs: ["get", "list", "watch", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Increases OpenClaw's cluster-wide scan capabilities to include listing logs and patching deployments/runners for restarts.