### PR TITLE
fix(headlamp): remove missing secret.yaml from kustomization

### DIFF
--- a/home-cluster/headlamp/kustomization.yaml
+++ b/home-cluster/headlamp/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - service.yaml
   - serviceaccount.yaml
   - clusterrolebinding.yaml
-  - secret.yaml
   - ingressroute.yaml
   - dnsendpoint.yaml
   - networkpolicy.yaml


### PR DESCRIPTION
Removes the reference to 'secret.yaml' in the headlamp kustomization, which was causing the Flux build failure.