### PR TITLE
feat(headlamp): allow external egress to port 443

### DIFF
--- a/home-cluster/headlamp/networkpolicy.yaml
+++ b/home-cluster/headlamp/networkpolicy.yaml
@@ -63,3 +63,24 @@ spec:
     ports:
     - protocol: TCP
       port: 443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: headlamp-allow-internet-egress
+  namespace: headlamp
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 10.0.0.0/8
+        - 192.168.0.0/16
+        - 172.16.0.0/12
+    ports:
+    - protocol: TCP
+      port: 443


### PR DESCRIPTION
Adds a NetworkPolicy allowing egress to the public internet on port 443 (excluding RFC1918) so Headlamp can download plugins.