### PR TITLE
fix: remove duplicate meshtastic resource and broken ollama deployment

### DIFF
--- a/home-cluster/ai-services/kustomization.yaml
+++ b/home-cluster/ai-services/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - network-policy.yaml
   - namespace.yaml
   - wyoming-whisper.yaml
-  - ollama.yaml
   - ollama-amd.yaml
   - open-webui.yaml
   - ingressroute.yaml

--- a/home-cluster/meshtastic/kustomization.yaml
+++ b/home-cluster/meshtastic/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingressroute.yaml
-  - ingressroute-tcp.yaml
   - dnsendpoint.yaml
   - external-secrets.yaml
 


### PR DESCRIPTION
## Summary
- Remove `ingressroute-tcp.yaml` from meshtastic kustomization (IngressRouteTCP is already defined in `ingressroute.yaml`, causing duplicate error)
- Remove `ollama.yaml` from ai-services kustomization (references non-existent 'beast' node; use `ollama-amd` deployments instead)

## Manual Action Required
The following orphaned Flux Kustomizations need to be deleted manually:
```bash
kubectl delete kustomization arc-runners -n flux-system
kubectl delete kustomization caddy-system -n flux-system
```
These reference paths (`home-cluster/arc-runners`, `home-cluster/caddy-system`) that no longer exist in git.