### PR TITLE
fix: add HelmRepository for spegel OCI chart

### DIFF
--- a/home-cluster/spegel/helmrelease.yaml
+++ b/home-cluster/spegel/helmrelease.yaml
@@ -7,7 +7,11 @@ spec:
   interval: 1h
   chart:
     spec:
-      chart: oci://ghcr.io/spegel-org/helm-charts/spegel
+      chart: spegel
+      sourceRef:
+        kind: HelmRepository
+        name: spegel
+        namespace: flux-system
       version: 0.6.0
   values:
     spegel:

--- a/home-cluster/spegel/helmrepository.yaml
+++ b/home-cluster/spegel/helmrepository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: spegel
+  namespace: flux-system
+spec:
+  interval: 1h
+  type: oci
+  url: oci://ghcr.io/spegel-org/helm-charts

--- a/home-cluster/spegel/kustomization.yaml
+++ b/home-cluster/spegel/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - network-policy.yaml
+  - helmrepository.yaml
   - helmrelease.yaml


### PR DESCRIPTION
## Summary
Add HelmRepository for spegel OCI chart. OCI-based Helm charts in Flux require a HelmRepository with `type: oci`.

## Changes
- Add `helmrepository.yaml` with OCI type for spegel
- Update `helmrelease.yaml` to reference the HelmRepository

## Manual Action Required
Delete orphaned Flux Kustomizations that reference non-existent paths:
```bash
kubectl delete kustomization arc-runners -n flux-system
kubectl delete kustomization caddy-system -n flux-system
```