### PR TITLE
migrate: actions-runner-controller to Flux

### DIFF
--- a/home-cluster/flux-system/syncs/actions-runner-controller-helmrepository.yaml
+++ b/home-cluster/flux-system/syncs/actions-runner-controller-helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: actions-runner-controller
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://actions-runner-controller.github.io/actions-runner-controller

--- a/home-cluster/github-runners/helmrelease.yaml
+++ b/home-cluster/github-runners/helmrelease.yaml
@@ -1,0 +1,37 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: actions-runner-controller
+  namespace: github-runners
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: actions-runner-controller/actions-runner-controller
+      version: 0.23.7
+      sourceRef:
+        kind: HelmRepository
+        name: actions-runner-controller
+        namespace: flux-system
+  install:
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    authSecret:
+      enabled: true
+      create: false
+      name: github-runner-secret
+    image:
+      repository: summerwind/actions-runner-controller
+    resources:
+      limits:
+        memory: 1Gi
+    env:
+      - name: REGISTRY_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: registry-secrets
+            key: REGISTRY_PASSWORD
+            optional: true

--- a/home-cluster/github-runners/kustomization.yaml
+++ b/home-cluster/github-runners/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 generatorOptions:
   disableNameSuffixHash: true
 resources:
+  - helmrelease.yaml
   - rbac.yaml
   - runner-deployment.yaml
   - external-secrets-store.yaml

--- a/home-cluster/helmfile.yaml
+++ b/home-cluster/helmfile.yaml
@@ -415,24 +415,3 @@ releases:
             cpu: 100m
           limits:
             memory: 512Mi
-  - name: actions-runner-controller
-    namespace: github-runners
-    chart: actions-runner-controller/actions-runner-controller
-    version: 0.23.7
-    values:
-      - authSecret:
-          enabled: true
-          create: false
-          name: github-runner-secret
-        image:
-          repository: summerwind/actions-runner-controller
-        resources:
-          limits:
-            memory: 1Gi
-        env:
-          - name: REGISTRY_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: registry-secrets
-                key: REGISTRY_PASSWORD
-                optional: true


### PR DESCRIPTION
## Summary
Migrate `actions-runner-controller` from helmfile to Flux.

## Changes
- Add HelmRepository for actions-runner-controller
- Add HelmRelease in github-runners directory
- Remove from helmfile

## Remaining helmfile releases (11)
```
reflector, reloader, metrics-server
oauth2-proxy (auth, headlamp, quotes)
external-dns, csi-driver-smb
plex, jellyfin, pihole
```