### PR TITLE
migrate: external-dns to Flux

### DIFF
--- a/home-cluster/flux-system/syncs/external-dns-helmrepository.yaml
+++ b/home-cluster/flux-system/syncs/external-dns-helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: external-dns
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/external-dns/

--- a/home-cluster/flux-system/syncs/kube-system-kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kube-system-kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kube-system
+  namespace: flux-system
+spec:
+  interval: 1h
+  path: ./home-cluster/kube-system
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters

--- a/home-cluster/flux-system/syncs/kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - traefik-helmrepository.yaml
   - prometheus-community-helmrepository.yaml
   - grafana-helmrepository.yaml
+  - external-dns-helmrepository.yaml
   - traefik-kustomization.yaml
   - cert-manager-kustomization.yaml
   - netalertx-kustomization.yaml
@@ -36,4 +37,5 @@ resources:
   - gpu-operator-kustomization.yaml
   - metallb-system-kustomization.yaml
   - github-runners-kustomization.yaml
+  - kube-system-kustomization.yaml
   - arc-kustomization.yaml

--- a/home-cluster/helmfile.yaml
+++ b/home-cluster/helmfile.yaml
@@ -200,46 +200,6 @@ releases:
             prometheus.io/path: "/metrics"
         ingress:
           enabled: false
-  - name: external-dns
-    namespace: kube-system
-    chart: external-dns/external-dns
-    version: 1.20.0
-    values:
-      - provider: cloudflare
-        cloudflare:
-          apiToken:
-            secretName: cloudflare-api-creds-root
-            secretKey: CLOUDFLARE_API_TOKEN
-        domainFilters:
-          - stevearnett.com
-        txtOwnerId: home-cluster
-        logLevel: debug
-        env:
-          - name: CF_API_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: cloudflare-api-creds-root
-                key: CLOUDFLARE_API_TOKEN
-        extraArgs:
-          - --source=crd
-          - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
-          - --crd-source-kind=DNSEndpoint
-          - --source=ingress
-        rbac:
-          additionalPermissions:
-            - apiGroups:
-                - "externaldns.k8s.io"
-              resources:
-                - "dnsendpoints"
-              verbs:
-                - "get"
-                - "watch"
-                - "list"
-        service:
-          annotations:
-            prometheus.io/scrape: "true"
-            prometheus.io/port: "7979"
-            prometheus.io/path: "/metrics"
   - name: csi-driver-smb
     namespace: kube-system
     chart: csi-driver-smb/csi-driver-smb

--- a/home-cluster/kube-system/external-dns-helmrelease.yaml
+++ b/home-cluster/kube-system/external-dns-helmrelease.yaml
@@ -1,0 +1,56 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-dns
+  namespace: kube-system
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: external-dns/external-dns
+      version: 1.20.0
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns
+        namespace: flux-system
+  install:
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    provider: cloudflare
+    cloudflare:
+      apiToken:
+        secretName: cloudflare-api-creds-root
+        secretKey: CLOUDFLARE_API_TOKEN
+    domainFilters:
+      - stevearnett.com
+    txtOwnerId: home-cluster
+    logLevel: debug
+    env:
+      - name: CF_API_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: cloudflare-api-creds-root
+            key: CLOUDFLARE_API_TOKEN
+    extraArgs:
+      - --source=crd
+      - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
+      - --crd-source-kind=DNSEndpoint
+      - --source=ingress
+    rbac:
+      additionalPermissions:
+        - apiGroups:
+            - "externaldns.k8s.io"
+          resources:
+            - "dnsendpoints"
+          verbs:
+            - "get"
+            - "watch"
+            - "list"
+    service:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7979"
+        prometheus.io/path: "/metrics"


### PR DESCRIPTION
## Summary
Migrate `external-dns` from helmfile to Flux.

## Changes
- Add HelmRepository for external-dns
- Add HelmRelease in kube-system directory
- Add kube-system to flux-system syncs
- Remove from helmfile

## Remaining helmfile releases (10)
```
reflector, reloader, metrics-server
oauth2-proxy (auth, headlamp, quotes)
csi-driver-smb
plex, jellyfin, pihole
```