### PR TITLE
fix: add missing HelmRepositories to flux-system

### DIFF
--- a/home-cluster/flux-system/syncs/external-secrets-helmrepository.yaml
+++ b/home-cluster/flux-system/syncs/external-secrets-helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: external-secrets
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.external-secrets.io

--- a/home-cluster/flux-system/syncs/kustomization.yaml
+++ b/home-cluster/flux-system/syncs/kustomization.yaml
@@ -10,6 +10,11 @@ resources:
   - external-dns-helmrepository.yaml
   - pihole-helmrepository.yaml
   - plexinc-helmrepository.yaml
+  - actions-runner-controller-helmrepository.yaml
+  - external-secrets-helmrepository.yaml
+  - nvidia-helmrepository.yaml
+  - renovate-helmrepository.yaml
+  - spegel-helmrepository.yaml
   - traefik-kustomization.yaml
   - cert-manager-kustomization.yaml
   - netalertx-kustomization.yaml

--- a/home-cluster/flux-system/syncs/nvidia-helmrepository.yaml
+++ b/home-cluster/flux-system/syncs/nvidia-helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: nvidia
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://nvidia.github.io/gpu-operator

--- a/home-cluster/flux-system/syncs/renovate-helmrepository.yaml
+++ b/home-cluster/flux-system/syncs/renovate-helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: renovate
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://docs.renovatebot.com/helm-charts

--- a/home-cluster/flux-system/syncs/spegel-helmrepository.yaml
+++ b/home-cluster/flux-system/syncs/spegel-helmrepository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: spegel
+  namespace: flux-system
+spec:
+  interval: 1h
+  type: oci
+  url: oci://ghcr.io/spegel-org/helm-charts


### PR DESCRIPTION
Fix Flux HelmReleases by adding missing HelmRepositories:
- external-secrets
- nvidia (gpu-operator)
- renovate
- spegel (OCI)
- actions-runner-controller