### PR TITLE
fix: apply flux-system/syncs HelmRepositories via Flux Kustomization

### DIFF
--- a/home-cluster/flux-system/flux-system-sources-kustomization.yaml
+++ b/home-cluster/flux-system/flux-system-sources-kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: flux-system-sources
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./home-cluster/flux-system/syncs
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters

--- a/home-cluster/flux-system/kustomization.yaml
+++ b/home-cluster/flux-system/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: flux-system
 resources:
   - gotk-components.yaml
   - arc-helmrepository.yaml
+  - flux-system-sources-kustomization.yaml


### PR DESCRIPTION
The HelmRepositories in  were never being applied because there was no Flux Kustomization pointing to that directory. This creates a Flux Kustomization () that applies , which will create all the HelmRepositories needed by the HelmReleases.