### PR TITLE
fix: add Flux Kustomization for flux-system/syncs

### DIFF
--- a/home-cluster/flux-system/kustomization.yaml
+++ b/home-cluster/flux-system/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - prometheus-community-helmrepository.yaml
   - grafana-helmrepository.yaml
   - actions-runner-controller-helmrepository.yaml
+  - syncs-kustomization.yaml

--- a/home-cluster/flux-system/syncs-kustomization.yaml
+++ b/home-cluster/flux-system/syncs-kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: flux-system-sources
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./home-cluster/flux-system/syncs
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: clusters


### PR DESCRIPTION
This creates a Flux Kustomization that points to ./home-cluster/flux-system/syncs, which will apply all the HelmRepositories and service Kustomizations in that directory.

The syncs directory contains all the HelmRepositories needed by the HelmReleases, but without a Flux Kustomization pointing to it, they weren't being applied.