### PR TITLE
fix: update HelmRelease sourceRef namespaces

### DIFF
--- a/home-cluster/auth/oauth2-proxy-helmrelease.yaml
+++ b/home-cluster/auth/oauth2-proxy-helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: oauth2-proxy
-        namespace: flux-system
+        namespace: auth
   install:
     createNamespace: true
   upgrade:

--- a/home-cluster/clustersecret/reflector-helmrelease.yaml
+++ b/home-cluster/clustersecret/reflector-helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: emberstack
-        namespace: flux-system
+        namespace: clustersecret
   install:
     createNamespace: true
   upgrade:

--- a/home-cluster/external-secrets/helmrelease.yaml
+++ b/home-cluster/external-secrets/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: external-secrets
-        namespace: flux-system
+        namespace: external-secrets
   install:
     createNamespace: true
   upgrade:

--- a/home-cluster/gpu-operator/helmrelease.yaml
+++ b/home-cluster/gpu-operator/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: nvidia
-        namespace: flux-system
+        namespace: gpu-operator
   values:
     operator:
       defaultRuntime: containerd

--- a/home-cluster/headlamp/oauth2-proxy-helmrelease.yaml
+++ b/home-cluster/headlamp/oauth2-proxy-helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: oauth2-proxy
-        namespace: flux-system
+        namespace: headlamp
   install:
     createNamespace: true
   upgrade:

--- a/home-cluster/kube-system/csi-driver-smb-helmrelease.yaml
+++ b/home-cluster/kube-system/csi-driver-smb-helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: csi-driver-smb
-        namespace: flux-system
+        namespace: kube-system
   install:
     createNamespace: true
   upgrade:

--- a/home-cluster/kube-system/external-dns-helmrelease.yaml
+++ b/home-cluster/kube-system/external-dns-helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: external-dns
-        namespace: flux-system
+        namespace: kube-system
   install:
     createNamespace: true
   upgrade:

--- a/home-cluster/kube-system/metrics-server-helmrelease.yaml
+++ b/home-cluster/kube-system/metrics-server-helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: metrics-server
-        namespace: flux-system
+        namespace: kube-system
   install:
     createNamespace: true
   upgrade:

--- a/home-cluster/kube-system/reloader-helmrelease.yaml
+++ b/home-cluster/kube-system/reloader-helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: stakater
-        namespace: flux-system
+        namespace: kube-system
   install:
     createNamespace: true
   upgrade:

--- a/home-cluster/media/jellyfin-helmrelease.yaml
+++ b/home-cluster/media/jellyfin-helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: jellyfin
-        namespace: flux-system
+        namespace: media
   install:
     createNamespace: true
   upgrade:

--- a/home-cluster/onepassword-connect/helmrelease.yaml
+++ b/home-cluster/onepassword-connect/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: onepassword
-        namespace: flux-system
+        namespace: onepassword-connect
   install:
     createNamespace: true
   upgrade:

--- a/home-cluster/pihole/helmrelease.yaml
+++ b/home-cluster/pihole/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: pihole
-        namespace: flux-system
+        namespace: pihole
   install:
     createNamespace: true
   upgrade:

--- a/home-cluster/plex/helmrelease.yaml
+++ b/home-cluster/plex/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: plexinc
-        namespace: flux-system
+        namespace: plex
   install:
     createNamespace: true
   upgrade:

--- a/home-cluster/quotes/oauth2-proxy-helmrelease.yaml
+++ b/home-cluster/quotes/oauth2-proxy-helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: oauth2-proxy
-        namespace: flux-system
+        namespace: quotes
   install:
     createNamespace: true
   upgrade:

--- a/home-cluster/renovate/helmrelease.yaml
+++ b/home-cluster/renovate/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: renovate
-        namespace: flux-system
+        namespace: renovate
   values:
     cronjob:
       schedule: "0 * * * *"

--- a/home-cluster/spegel/helmrelease.yaml
+++ b/home-cluster/spegel/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: spegel
-        namespace: flux-system
+        namespace: spegel
       version: 0.6.0
   values:
     spegel:


### PR DESCRIPTION
Update HelmRelease sourceRef.namespace from flux-system to the service's namespace so they can find their HelmRepositories which are now co-located with their HelmReleases.