### PR TITLE
fix: fix HelmRelease chart names

### DIFF
--- a/home-cluster/clustersecret/reflector-helmrelease.yaml
+++ b/home-cluster/clustersecret/reflector-helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 1h
   chart:
     spec:
-      chart: emberstack/reflector
+      chart: reflector
       version: 10.0.22
       sourceRef:
         kind: HelmRepository

--- a/home-cluster/media/jellyfin-helmrelease.yaml
+++ b/home-cluster/media/jellyfin-helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 1h
   chart:
     spec:
-      chart: jellyfin/jellyfin
+      chart: jellyfin
       version: 2.7.0
       sourceRef:
         kind: HelmRepository

--- a/home-cluster/onepassword-connect/helmrelease.yaml
+++ b/home-cluster/onepassword-connect/helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 1h
   chart:
     spec:
-      chart: 1password/connect
+      chart: connect
       version: 2.4.0
       sourceRef:
         kind: HelmRepository

--- a/home-cluster/pihole/helmrelease.yaml
+++ b/home-cluster/pihole/helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 1h
   chart:
     spec:
-      chart: pihole-v6/pihole
+      chart: pihole
       version: 1.2.1
       sourceRef:
         kind: HelmRepository

--- a/home-cluster/plex/helmrelease.yaml
+++ b/home-cluster/plex/helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 1h
   chart:
     spec:
-      chart: plexinc/plex-media-server
+      chart: plex
       version: "1.5.0"
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Remove repo prefix from chart names since sourceRef already specifies the repository.