### PR TITLE
fix: fix remaining HelmRelease chart names

### DIFF
--- a/home-cluster/auth/oauth2-proxy-helmrelease.yaml
+++ b/home-cluster/auth/oauth2-proxy-helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 1h
   chart:
     spec:
-      chart: oauth2-proxy/oauth2-proxy
+      chart: oauth2-proxy
       version: 10.3.0
       sourceRef:
         kind: HelmRepository

--- a/home-cluster/external-secrets/helmrelease.yaml
+++ b/home-cluster/external-secrets/helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 1h
   chart:
     spec:
-      chart: external-secrets/external-secrets
+      chart: external-secrets
       version: 2.2.0
       sourceRef:
         kind: HelmRepository

--- a/home-cluster/github-runners/helmrelease.yaml
+++ b/home-cluster/github-runners/helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 1h
   chart:
     spec:
-      chart: actions-runner-controller/actions-runner-controller
+      chart: actions-runner-controller
       version: 0.23.7
       sourceRef:
         kind: HelmRepository

--- a/home-cluster/headlamp/oauth2-proxy-helmrelease.yaml
+++ b/home-cluster/headlamp/oauth2-proxy-helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 1h
   chart:
     spec:
-      chart: oauth2-proxy/oauth2-proxy
+      chart: oauth2-proxy
       version: 10.3.0
       sourceRef:
         kind: HelmRepository

--- a/home-cluster/quotes/oauth2-proxy-helmrelease.yaml
+++ b/home-cluster/quotes/oauth2-proxy-helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 1h
   chart:
     spec:
-      chart: oauth2-proxy/oauth2-proxy
+      chart: oauth2-proxy
       version: 10.3.0
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Remove repo prefix from chart names for oauth2-proxy, external-secrets, and actions-runner-controller.