### PR TITLE
fix: allow clustersecret egress to all namespaces

### DIFF
--- a/home-cluster/clustersecret/network-policy.yaml
+++ b/home-cluster/clustersecret/network-policy.yaml
@@ -9,17 +9,15 @@ spec:
   - Ingress
   - Egress
   egress:
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-    ports:
+  - ports:
     - protocol: UDP
       port: 53
     - protocol: TCP
       port: 53
     - protocol: TCP
       port: 443
+    to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - namespaceSelector: {}


### PR DESCRIPTION
Allow clustersecret namespace to reach K8s API in default namespace