### PR TITLE
feat(network): allow connectivity between flux and external-secrets-webhook

### DIFF
--- a/home-cluster/external-secrets/eso-flux-networkpolicy.yaml
+++ b/home-cluster/external-secrets/eso-flux-networkpolicy.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: flux-allow-eso-egress
+  namespace: flux-system
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: external-secrets
+    ports:
+    - protocol: TCP
+      port: 443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eso-allow-flux-ingress
+  namespace: external-secrets
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets-webhook
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: flux-system
+    ports:
+    - protocol: TCP
+      port: 10250 # The webhook server port inside the pod
+    - protocol: TCP
+      port: 443   # The service port


### PR DESCRIPTION
Specifically allows flux-system controllers to reach the external-secrets-webhook for secret validation, helping clear the dry-run timeouts.