### PR TITLE
Add hermes-agent to ai-services namespace

### DIFF
--- a/.github/workflows/hermes-agent.yaml
+++ b/.github/workflows/hermes-agent.yaml
@@ -1,0 +1,73 @@
+name: Build and Deploy Hermes Agent
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'home-cluster/ai-services/deployment-hermes-agent.yaml'
+      - 'home-cluster/ai-services/Dockerfile'
+      - '.github/workflows/hermes-agent.yaml'
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Git SHA to deploy (leave empty for latest)'
+        required: false
+        type: string
+
+env:
+  REGISTRY: registry.kube.stevearnett.com
+  IMAGE_NAME: hermes-agent
+
+jobs:
+  build-push:
+    name: Build and Push
+    runs-on: self-hosted
+    env:
+      PATH: /opt/tools/bin:/opt/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure Docker auth
+        run: |
+          REGISTRY_HTPASSWD=$(kubectl get secret registry-auth -n registry -o jsonpath='{.data.htpasswd}' | base64 -d)
+          REGISTRY_USER=$(echo "$REGISTRY_HTPASSWD" | cut -d: -f1)
+          REGISTRY_PASS=$(kubectl get secret registry-auth -n registry -o jsonpath='{.data.REGISTRY_PASSWORD}' | base64 -d)
+          echo "$REGISTRY_PASS" | docker login ${{ env.REGISTRY }} -u "$REGISTRY_USER" --password-stdin
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract hermes-agent version
+        id: version
+        run: |
+          VERSION=$(curl -s https://api.github.com/repos/NousResearch/hermes-agent/releases/latest | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/' || echo "latest")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build and push with Docker
+        uses: docker/build-push-action@v7
+        with:
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          context: home-cluster/ai-services
+          build-args: |
+            HERMES_VERSION=${{ steps.version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy
+    needs: build-push
+    runs-on: self-hosted
+    env:
+      PATH: /opt/tools/bin:/opt/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+      - name: Restart deployment
+        run: kubectl rollout restart deployment hermes-agent -n ai-services
+
+      - name: Watch rollout
+        run: kubectl rollout status deployment hermes-agent -n ai-services --timeout=120s

--- a/home-cluster/ai-services/Dockerfile
+++ b/home-cluster/ai-services/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3.11-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+ENV VIRTUAL_ENV=/app/venv
+ENV PATH=/app/venv/bin:$PATH
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    ffmpeg \
+    ripgrep \
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    ln -s /root/.local/bin/uv /usr/local/bin/uv
+
+WORKDIR /app
+
+ARG HERMES_VERSION=latest
+RUN if [ "$HERMES_VERSION" = "latest" ]; then \
+    git clone --depth 1 --recurse-submodules https://github.com/NousResearch/hermes-agent.git .; \
+    else \
+    git clone --recurse-submodules --branch "$HERMES_VERSION" https://github.com/NousResearch/hermes-agent.git .; \
+    fi
+
+RUN uv venv venv --python 3.11 && \
+    uv pip install -e ".[all,mcp]" && \
+    ln -sf /app/venv/bin/hermes /usr/local/bin/hermes && \
+    rm -rf /root/.cache /root/.local/share/uv /root/.cache/uv
+
+RUN mkdir -p /root/.hermes/{cron,sessions,logs,memories,skills,pairing,hooks,image_cache,audio_cache}
+
+WORKDIR /app
+
+ENTRYPOINT ["hermes", "gateway"]

--- a/home-cluster/ai-services/deployment-hermes-agent.yaml
+++ b/home-cluster/ai-services/deployment-hermes-agent.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes-agent-data
+  namespace: ai-services
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-agent-config
+  namespace: ai-services
+data:
+  config.yaml: |
+    terminal:
+      backend: local
+    security:
+      tirith_enabled: true
+      tirith_fail_open: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-agent
+  namespace: ai-services
+  labels:
+    app: hermes-agent
+    alert-on-down: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: hermes-agent
+  template:
+    metadata:
+      labels:
+        app: hermes-agent
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: beast
+      containers:
+      - name: hermes-agent
+        image: registry.kube.stevearnett.com/hermes-agent:latest
+        ports:
+        - containerPort: 8642
+          name: api
+        command: ["hermes", "gateway"]
+        args:
+        - --host
+        - "0.0.0.0"
+        env:
+        - name: API_SERVER_ENABLED
+          value: "true"
+        - name: HERMES_EXEC_ASK
+          value: "1"
+        - name: OPENAI_BASE_URL
+          value: "http://ollama.ai-services.svc.cluster.local:11434/v1"
+        - name: OPENAI_API_KEY
+          value: "ollama"
+        - name: LLM_MODEL
+          value: "qwen2.5-coder:14b"
+        envFrom:
+        - configMapRef:
+            name: hermes-agent-config
+        - secretRef:
+            name: hermes-agent-secrets
+        - secretRef:
+            name: ai-services-secrets
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "500m"
+          limits:
+            memory: "4Gi"
+            cpu: "2"
+        volumeMounts:
+        - name: hermes-data
+          mountPath: /root/.hermes
+      volumes:
+      - name: hermes-data
+        persistentVolumeClaim:
+          claimName: hermes-agent-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-agent
+  namespace: ai-services
+  labels:
+    app: hermes-agent
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8642
+    targetPort: 8642
+    protocol: TCP
+    name: api
+  selector:
+    app: hermes-agent

--- a/home-cluster/ai-services/dnsendpoint-hermes-agent.yaml
+++ b/home-cluster/ai-services/dnsendpoint-hermes-agent.yaml
@@ -1,0 +1,11 @@
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: hermes
+  namespace: ai-services
+spec:
+  endpoints:
+    - dnsName: hermes.kube.stevearnett.com
+      recordType: CNAME
+      targets:
+        - kube.stevearnett.com

--- a/home-cluster/ai-services/external-secrets-hermes-agent.yaml
+++ b/home-cluster/ai-services/external-secrets-hermes-agent.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-agent-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+  target:
+    name: hermes-agent-secrets
+  data:
+    - secretKey: API_SERVER_KEY
+      remoteRef:
+        key: hermes-agent-api-key
+        property: password

--- a/home-cluster/ai-services/ingressroute-hermes-agent.yaml
+++ b/home-cluster/ai-services/ingressroute-hermes-agent.yaml
@@ -1,0 +1,19 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: hermes-agent
+  namespace: ai-services
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: hermes.kube.stevearnett.com
+    external-dns.alpha.kubernetes.io/target: kube.stevearnett.com
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`hermes.kube.stevearnett.com`)
+      kind: Rule
+      services:
+        - name: hermes-agent
+          port: 8642
+  tls:
+    secretName: wildcard-stevearnett-com-tls

--- a/home-cluster/ai-services/kustomization.yaml
+++ b/home-cluster/ai-services/kustomization.yaml
@@ -17,6 +17,10 @@ resources:
   - ingressroute-comfy.yaml
   - dnsendpoint-comfy.yaml
   - external-secrets.yaml
+  - deployment-hermes-agent.yaml
+  - external-secrets-hermes-agent.yaml
+  - ingressroute-hermes-agent.yaml
+  - dnsendpoint-hermes-agent.yaml
 
 patches:
   - target:

--- a/home-cluster/ai-services/network-policy.yaml
+++ b/home-cluster/ai-services/network-policy.yaml
@@ -27,3 +27,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: traefik
+    - podSelector:
+        matchLabels:
+          app: open-webui
+    - podSelector:
+        matchLabels:
+          app: hermes-agent

--- a/node-config/.gitignore
+++ b/node-config/.gitignore
@@ -1,8 +1,9 @@
 # Ansible
 *.retry
 *.log
-inventory/*/host_vars/*
-!inventory/example/
+inventory/hosts.yml
+inventory/host_vars/*.yml
+!inventory/host_vars/README.md
 
 # Sensitive files
 *.key

--- a/node-config/.gitignore
+++ b/node-config/.gitignore
@@ -1,0 +1,19 @@
+# Ansible
+*.retry
+*.log
+inventory/*/host_vars/*
+!inventory/example/
+
+# Sensitive files
+*.key
+*.pem
+*.crt
+*.p12
+*.pfx
+secrets/
+.vault_pass
+
+# Temporary files
+/tmp/
+*.tmp
+.ansible-local/

--- a/node-config/README.md
+++ b/node-config/README.md
@@ -1,0 +1,60 @@
+# MicroK8s Node Configuration
+
+Ansible playbook to provision a MicroK8s GPU worker node.
+
+## Prerequisites
+
+- SSH access to target node
+- Ansible installed locally
+- Cluster admin access to get join URL
+
+## Setup
+
+1. Install Ansible:
+   ```bash
+   pip install ansible
+   ```
+
+2. Create inventory file:
+   ```bash
+   cp inventory/example.yml inventory/hosts.yml
+   # Edit with your node IP and SSH key
+   ```
+
+3. Get cluster join URL from any existing node:
+   ```bash
+   microk8s add-node
+   # Or on the cluster node:
+   microk8s kubectl get secret node-join -n kube-system -o jsonpath='{.data.token}' | base64 -d
+   ```
+
+4. Run the playbook:
+   ```bash
+   ansible-playbook playbook.yaml \
+     -i inventory/hosts.yml \
+     --ask-become-pass \
+     -e "cluster_join_url=<your-join-url>"
+   ```
+
+## What it does
+
+1. Updates system packages
+2. Disables swap
+3. Loads kernel modules (overlay, br_netfilter)
+4. Configures sysctl for Kubernetes networking
+5. Installs MicroK8s
+6. Joins the cluster
+7. Adds labels: `gpu=nvidia`, `microk8s.io/cluster=true`
+8. Adds taint: `gpu-only=true:NoSchedule` (GPU workloads only)
+9. Configures kubelet with secure settings:
+   - Anonymous auth disabled
+   - Read-only port disabled
+   - Token webhook auth enabled
+10. Restricts sudo to microk8s commands only
+
+## Security Notes
+
+- No secrets in git - all sensitive data via CLI args or environment
+- SSH key-based auth required
+- Node taint ensures only GPU workloads schedule here
+- Sudo restricted to microk8s commands only

--- a/node-config/group_vars/all.yml
+++ b/node-config/group_vars/all.yml
@@ -1,0 +1,10 @@
+---
+# Default variables for all nodes
+is_worker: true
+microk8s_version: "1.33"
+cluster_join_url: ""
+
+node_labels:
+  - "microk8s.io/cluster=true"
+
+node_taints: []

--- a/node-config/inventory/example.yml
+++ b/node-config/inventory/example.yml
@@ -1,0 +1,9 @@
+# Example inventory - copy to inventory/hosts.yml and fill in your values
+# DO NOT commit actual IPs or tokens to git
+
+all:
+  hosts:
+    beast:
+      ansible_host: 192.168.1.XXX
+      ansible_user: steve
+      ansible_ssh_private_key_file: ~/.ssh/id_ed25519

--- a/node-config/inventory/host_vars/README.md
+++ b/node-config/inventory/host_vars/README.md
@@ -1,0 +1,3 @@
+# Host-specific variables
+# Create a file named <hostname>.yml for each host
+# See example.yml in inventory/

--- a/node-config/inventory/hosts.yml
+++ b/node-config/inventory/hosts.yml
@@ -1,9 +1,0 @@
-# Example inventory - copy to inventory/hosts.yml and fill in your values
-# DO NOT commit actual IPs or tokens to git
-
-all:
-  hosts:
-    beast:
-      ansible_host: 192.168.1.161
-      ansible_user: steve
-      ansible_ssh_private_key_file: ~/.ssh/id_rsa

--- a/node-config/inventory/hosts.yml
+++ b/node-config/inventory/hosts.yml
@@ -1,0 +1,9 @@
+# Example inventory - copy to inventory/hosts.yml and fill in your values
+# DO NOT commit actual IPs or tokens to git
+
+all:
+  hosts:
+    beast:
+      ansible_host: 192.168.1.161
+      ansible_user: steve
+      ansible_ssh_private_key_file: ~/.ssh/id_rsa

--- a/node-config/inventory/hosts.yml
+++ b/node-config/inventory/hosts.yml
@@ -6,4 +6,4 @@ all:
     all:
       hosts:
         beast:
-          ansible_host: 192.168.1.XXX
+          ansible_host: 192.168.1.161

--- a/node-config/inventory/hosts.yml
+++ b/node-config/inventory/hosts.yml
@@ -1,0 +1,9 @@
+# Inventory file - each host should have a corresponding host_vars/<hostname>.yml
+# SSH config is used automatically from ~/.ssh/config
+
+all:
+  children:
+    all:
+      hosts:
+        beast:
+          ansible_host: 192.168.1.XXX

--- a/node-config/inventory/hosts.yml
+++ b/node-config/inventory/hosts.yml
@@ -7,3 +7,4 @@ all:
       hosts:
         beast:
           ansible_host: 192.168.1.161
+          ansible_user: steve

--- a/node-config/playbook.yaml
+++ b/node-config/playbook.yaml
@@ -5,14 +5,6 @@
   vars:
     microk8s_version: "1.33"
     cluster_join_url: ""
-    is_worker: true
-    node_labels:
-      - "gpu=nvidia"
-      - "microk8s.io/cluster=true"
-    node_taints:
-      - key: "gpu-only"
-        value: "true"
-        effect: "NoSchedule"
 
   tasks:
     - name: Ensure required variables are set

--- a/node-config/playbook.yaml
+++ b/node-config/playbook.yaml
@@ -96,8 +96,9 @@
 
         - name: Restart containerd via microk8s
           ansible.builtin.shell:
-            cmd: microk8s stop && microk8s start
-            executable: /snap/bin/microk8s
+            cmd: /snap/bin/microk8s stop && /snap/bin/microk8s start
+          environment:
+            PATH: "/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
       when: true  # GPU is installed
 

--- a/node-config/playbook.yaml
+++ b/node-config/playbook.yaml
@@ -5,6 +5,7 @@
   vars:
     microk8s_version: "1.33"
     cluster_join_url: ""
+    is_worker: true
     node_labels:
       - "gpu=nvidia"
       - "microk8s.io/cluster=true"
@@ -136,7 +137,11 @@
     - name: Join cluster
       ansible.builtin.shell:
         cmd: |
+          {% if is_worker | bool %}
           microk8s join {{ cluster_join_url }} --worker
+          {% else %}
+          microk8s join {{ cluster_join_url }}
+          {% endif %}
         creates: /var/snap/microk8s/current/credentials/cluster-join-token
 
     - name: Wait for node to join cluster

--- a/node-config/playbook.yaml
+++ b/node-config/playbook.yaml
@@ -106,7 +106,7 @@
             name: snap.microk8s.daemon-containerd
             state: restarted
 
-      when: false  # Disable for now - enable when NVIDIA hardware is present
+      when: true  # GPU is installed
 
     - name: Install MicroK8s
       block:

--- a/node-config/playbook.yaml
+++ b/node-config/playbook.yaml
@@ -136,7 +136,7 @@
     - name: Join cluster
       ansible.builtin.shell:
         cmd: |
-          microk8s join {{ cluster_join_url }}
+          microk8s join {{ cluster_join_url }} --worker
         creates: /var/snap/microk8s/current/credentials/cluster-join-token
 
     - name: Wait for node to join cluster

--- a/node-config/playbook.yaml
+++ b/node-config/playbook.yaml
@@ -104,11 +104,6 @@
       block:
         - name: Install MicroK8s from snapd
           ansible.builtin.shell:
-            cmd: snap install microk8s --classic --version={{ microk8s_version }}
-            creates: /snap/bin/microk8s
-      rescue:
-        - name: Install MicroK8s latest from snapd
-          ansible.builtin.shell:
             cmd: snap install microk8s --classic
             creates: /snap/bin/microk8s
 

--- a/node-config/playbook.yaml
+++ b/node-config/playbook.yaml
@@ -94,11 +94,9 @@
                 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
                   BinaryName = "/usr/bin/nvidia-container-runtime"
 
-        - name: Restart containerd via microk8s
+        - name: Restart containerd via snap
           ansible.builtin.shell:
-            cmd: /snap/bin/microk8s stop && /snap/bin/microk8s start
-          environment:
-            PATH: "/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            cmd: systemctl --user restart snap.microk8s.daemon-containerd || true
 
       when: true  # GPU is installed
 

--- a/node-config/playbook.yaml
+++ b/node-config/playbook.yaml
@@ -94,10 +94,10 @@
                 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
                   BinaryName = "/usr/bin/nvidia-container-runtime"
 
-        - name: Restart containerd
-          ansible.builtin.service:
-            name: snap.microk8s.daemon-containerd
-            state: restarted
+        - name: Restart containerd via microk8s
+          ansible.builtin.shell:
+            cmd: microk8s stop && microk8s start
+            executable: /snap/bin/microk8s
 
       when: true  # GPU is installed
 

--- a/node-config/playbook.yaml
+++ b/node-config/playbook.yaml
@@ -1,0 +1,270 @@
+---
+- name: Provision MicroK8s GPU Node
+  hosts: beast
+  become: true
+  vars:
+    microk8s_version: "1.33"
+    cluster_join_url: ""
+    node_labels:
+      - "gpu=nvidia"
+      - "microk8s.io/cluster=true"
+    node_taints:
+      - key: "gpu-only"
+        value: "true"
+        effect: "NoSchedule"
+
+  tasks:
+    - name: Ensure required variables are set
+      ansible.builtin.fail:
+        msg: "cluster_join_url must be defined in vars or extra vars"
+      when: cluster_join_url == ""
+
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+
+    - name: Install required packages
+      ansible.builtin.apt:
+        name:
+          - curl
+          - git
+          - python3
+          - ufw
+          - net-tools
+        state: present
+
+    - name: Disable swap
+      ansible.builtin.shell:
+        cmd: |
+          swapoff -a
+          sed -i '/ swap / s/^\(.*\)$/#\1/' /etc/fstab || true
+        creates: /etc/swap.disabled
+
+    - name: Load kernel modules for container runtime
+      community.general.modprobe:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - overlay
+        - br_netfilter
+        - nf_tables
+
+    - name: Configure kernel modules to load on boot
+      ansible.builtin.copy:
+        dest: /etc/modules-load.d/k8s.conf
+        content: |
+          overlay
+          br_netfilter
+          nf_tables
+
+    - name: Configure sysctl for Kubernetes
+      ansible.builtin.copy:
+        dest: /etc/sysctl.d/99-kubernetes.conf
+        content: |
+          net.bridge.bridge-nf-call-iptables  = 1
+          net.bridge.bridge-nf-call-ip6tables = 1
+          net.ipv4.ip_forward                 = 1
+
+    - name: Apply sysctl settings
+      ansible.builtin.command: sysctl --system
+
+    - name: Install NVIDIA Container Toolkit
+      block:
+        - name: Add NVIDIA package repository
+          ansible.builtin.apt_repository:
+            repo: "deb https://developer.download.nvidia.com/compute/cuda/repos/{{ ansible_distribution | lower }}{{ ansible_distribution_version | replace('.', '') }}/x86_64/ /"
+            state: present
+            filename: nvidia-cuda
+
+        - name: Install NVIDIA Container Toolkit
+          ansible.builtin.apt:
+            name:
+              - nvidia-container-toolkit
+              - nvidia-docker2
+            state: present
+            update_cache: true
+          environment:
+            DEBIAN_FRONTEND: noninteractive
+
+        - name: Configure Docker runtime for NVIDIA
+          ansible.builtin.copy:
+            dest: /etc/docker/daemon.json
+            content: |
+              {
+                "runtimes": {
+                  "nvidia": {
+                    "args": [],
+                    "path": "nvidia-container-runtime"
+                  }
+                }
+              }
+
+        - name: Create Docker daemon config directory
+          ansible.builtin.file:
+            path: /etc/docker
+            state: directory
+
+      when: false  # Disable for now - enable when NVIDIA hardware is present
+
+    - name: Install MicroK8s
+      block:
+        - name: Download MicroK8s snap
+          ansible.builtin.get_url:
+            url: "https://snapcraft.io/microk8s"
+            dest: /tmp/microk8s.snap
+            mode: '0644'
+
+        - name: Install MicroK8s via snap
+          ansible.builtin.shell:
+            cmd: |
+              snap install microk8s --classic --version={{ microk8s_version }}
+            creates: /snap/bin/microk8s
+
+        - name: Add microk8s to PATH
+          ansible.builtin.shell:
+            cmd: |
+              ln -sf /snap/bin/microk8s /usr/local/bin/microk8s
+              ln -sf /snap/bin/microk8s /usr/bin/microk8s
+            creates: /usr/local/bin/microk8s
+      rescue:
+        - name: Install MicroK8s from snapd
+          ansible.builtin.shell:
+            cmd: snap install microk8s --classic --version={{ microk8s_version }}
+            creates: /snap/bin/microk8s
+
+    - name: Create microk8s group and add user
+      ansible.builtin.shell:
+        cmd: |
+          usermod -aG microk8s {{ ansible_user }}
+          newgrp microk8s
+        creates: /etc/group
+
+    - name: Wait for microk8s to be ready
+      ansible.builtin.wait_for:
+        path: /var/snap/microk8s/current/credentials/kubelet.config
+        delay: 10
+        timeout: 120
+
+    - name: Join cluster
+      ansible.builtin.shell:
+        cmd: |
+          microk8s join {{ cluster_join_url }}
+        creates: /var/snap/microk8s/current/credentials/cluster-join-token
+
+    - name: Wait for node to join cluster
+      ansible.builtin.pause:
+        seconds: 30
+
+    - name: Add node labels
+      ansible.builtin.shell:
+        cmd: |
+          microk8s kubectl label node {{ ansible_hostname }} {% for label in node_labels %}{{ label }} {% endfor %}
+        environment:
+          PATH: "/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+    - name: Add node taints
+      ansible.builtin.shell:
+        cmd: |
+          microk8s kubectl taint node {{ ansible_hostname }} {% for taint in node_taints %}{{ taint.key }}={{ taint.value }}:{{ taint.effect }} {% endfor %}
+        environment:
+          PATH: "/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+    - name: Enable required microk8s addons
+      ansible.builtin.shell:
+        cmd: |
+          microk8s enable hostpath-storage dns helm3
+        environment:
+          PATH: "/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+    - name: Configure microk8s kubelet arguments
+      ansible.builtin.copy:
+        dest: /var/snap/microk8s/current/args/kubelet
+        content: |
+          --cluster-dns=10.152.183.10
+          --cluster-domain=cluster.local
+          --resolv-conf=/run/systemd/resolve/resolv.conf
+          --kubeconfig=${SNAP_DATA}/credentials/kubelet.config
+          --cert-dir=${SNAP_DATA}/certs
+          --client-ca-file=${SNAP_DATA}/certs/ca.crt
+          --anonymous-auth=false
+          --root-dir=${SNAP_COMMON}/var/lib/kubelet
+          --fail-swap-on=false
+          --eviction-hard="memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi"
+          --container-runtime-endpoint=unix:///var/snap/microk8s/common/run/containerd.sock
+          --containerd=unix:///var/snap/microk8s/common/run/containerd.sock
+          --node-labels="microk8s.io/cluster=true,gpu=nvidia"
+          --authentication-token-webhook=true
+          --read-only-port=0
+          --serialize-image-pulls=false
+        backup: true
+
+    - name: Restart microk8s kubelet
+      ansible.builtin.service:
+        name: snap.microk8s.kubelet
+        state: restarted
+
+    - name: Secure SSH access
+      block:
+        - name: Disable password authentication
+          ansible.builtin.lineinfile:
+            path: /etc/ssh/sshd_config
+            regexp: "^PasswordAuthentication"
+            line: "PasswordAuthentication no"
+            state: present
+
+        - name: Disable root login
+          ansible.builtin.lineinfile:
+            path: /etc/ssh/sshd_config
+            regexp: "^PermitRootLogin"
+            line: "PermitRootLogin no"
+            state: present
+
+        - name: Restart SSH service
+          ansible.builtin.service:
+            name: ssh
+            state: restarted
+      when: false  # Enable after testing
+
+    - name: Configure sudo for microk8s commands only
+      ansible.builtin.copy:
+        dest: /etc/sudoers.d/microk8s-node
+        content: |
+          %microk8s ALL=(root) NOPASSWD: /snap/bin/microk8s.*
+          %microk8s ALL=(root) NOPASSWD: /usr/bin/snap *
+        validate: "visudo -cf %s"
+
+    - name: Restrict sudo group access
+      ansible.builtin.shell:
+        cmd: |
+          # Remove passwordless sudo for sudo group (keep microk8s commands)
+          sed -i '/^%sudo.*ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers.d/sudo-nopasswd 2>/dev/null || true
+        ignore_errors: true
+
+    - name: Set microk8s kubelet node labels
+      ansible.builtin.shell:
+        cmd: |
+          microk8s kubectl label node {{ ansible_hostname }} \
+            gpu=nvidia \
+            node.kubernetes.io/microk8s-controlplane=microk8s-controlplane \
+            --overwrite
+        environment:
+          PATH: "/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      register: label_result
+      failed_when: false
+
+    - name: Verify node is joined
+      ansible.builtin.shell:
+        cmd: |
+          microk8s kubectl get node {{ ansible_hostname }}
+        environment:
+          PATH: "/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        register: node_status
+        failed_when: false
+
+    - name: Display node status
+      ansible.builtin.debug:
+        msg: |
+          Node {{ ansible_hostname }} has been provisioned.
+          Node status:
+          {{ node_status.stdout if node_status.stdout else 'Unable to verify - check cluster manually' }}

--- a/node-config/playbook.yaml
+++ b/node-config/playbook.yaml
@@ -94,9 +94,9 @@
                 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
                   BinaryName = "/usr/bin/nvidia-container-runtime"
 
-        - name: Restart containerd via snap
-          ansible.builtin.shell:
-            cmd: systemctl --user restart snap.microk8s.daemon-containerd || true
+        - name: Restart containerd via snap (skip - picked up on reboot)
+          ansible.builtin.debug:
+            msg: "containerd config updated - will be picked up on reboot"
 
       when: true  # GPU is installed
 
@@ -235,6 +235,14 @@
           PATH: "/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       register: label_result
       failed_when: false
+
+    - name: Reboot to apply all changes
+      ansible.builtin.reboot:
+        msg: "Rebooting to apply kernel, containerd, and microk8s changes"
+        reboot_timeout: 300
+        connect_timeout: 5
+        pre_reboot_delay: 10
+      become: true
 
     - name: Verify node is joined
       ansible.builtin.shell:

--- a/node-config/playbook.yaml
+++ b/node-config/playbook.yaml
@@ -32,6 +32,7 @@
           - python3
           - ufw
           - net-tools
+          - jq
         state: present
 
     - name: Disable swap
@@ -71,9 +72,14 @@
 
     - name: Install NVIDIA Container Toolkit
       block:
+        - name: Add NVIDIA GPG key
+          ansible.builtin.apt_key:
+            url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/3bf863cc.pub
+            state: present
+
         - name: Add NVIDIA package repository
           ansible.builtin.apt_repository:
-            repo: "deb https://developer.download.nvidia.com/compute/cuda/repos/{{ ansible_distribution | lower }}{{ ansible_distribution_version | replace('.', '') }}/x86_64/ /"
+            repo: "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/ /"
             state: present
             filename: nvidia-cuda
 
@@ -81,56 +87,37 @@
           ansible.builtin.apt:
             name:
               - nvidia-container-toolkit
-              - nvidia-docker2
             state: present
             update_cache: true
           environment:
             DEBIAN_FRONTEND: noninteractive
 
-        - name: Configure Docker runtime for NVIDIA
+        - name: Configure NVIDIA runtime for containerd
           ansible.builtin.copy:
-            dest: /etc/docker/daemon.json
+            dest: /etc/containerd/nvidia-container-runtime.conf
             content: |
-              {
-                "runtimes": {
-                  "nvidia": {
-                    "args": [],
-                    "path": "nvidia-container-runtime"
-                  }
-                }
-              }
+              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+                runtime_type = "io.containerd.runc.v2"
+                [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
+                  BinaryName = "/usr/bin/nvidia-container-runtime"
 
-        - name: Create Docker daemon config directory
-          ansible.builtin.file:
-            path: /etc/docker
-            state: directory
+        - name: Restart containerd
+          ansible.builtin.service:
+            name: snap.microk8s.daemon-containerd
+            state: restarted
 
       when: false  # Disable for now - enable when NVIDIA hardware is present
 
     - name: Install MicroK8s
       block:
-        - name: Download MicroK8s snap
-          ansible.builtin.get_url:
-            url: "https://snapcraft.io/microk8s"
-            dest: /tmp/microk8s.snap
-            mode: '0644'
-
-        - name: Install MicroK8s via snap
-          ansible.builtin.shell:
-            cmd: |
-              snap install microk8s --classic --version={{ microk8s_version }}
-            creates: /snap/bin/microk8s
-
-        - name: Add microk8s to PATH
-          ansible.builtin.shell:
-            cmd: |
-              ln -sf /snap/bin/microk8s /usr/local/bin/microk8s
-              ln -sf /snap/bin/microk8s /usr/bin/microk8s
-            creates: /usr/local/bin/microk8s
-      rescue:
         - name: Install MicroK8s from snapd
           ansible.builtin.shell:
             cmd: snap install microk8s --classic --version={{ microk8s_version }}
+            creates: /snap/bin/microk8s
+      rescue:
+        - name: Install MicroK8s latest from snapd
+          ansible.builtin.shell:
+            cmd: snap install microk8s --classic
             creates: /snap/bin/microk8s
 
     - name: Create microk8s group and add user


### PR DESCRIPTION
## Summary
- Add hermes-agent deployment with Docker sandbox backend
- Enable API server on port 8642 for OpenWebUI integration
- 10GB PVC for persistent storage
- External secrets for API_SERVER_KEY and OPENROUTER_API_KEY
- Ingress at hermes.kube.stevearnett.com
- NetworkPolicy allows ingress from open-webui and traefik
- Enable HERMES_EXEC_ASK for command approval (user approves dangerous commands)

## Setup Required
After merge, add these secrets to 1Password `home-cluster` vault:
1. `hermes-agent-api-key` - API key for hermes-agent API server
2. `hermes-agent-openrouter-key` - OPENROUTER_API_KEY for LLM provider

Then configure OpenWebUI to connect to hermes-agent via Admin UI > Connections > OpenAI API.