### PR TITLE
external-secrets: increase webhook timeout to 60s

### DIFF
--- a/home-cluster/external-secrets/helmrelease.yaml
+++ b/home-cluster/external-secrets/helmrelease.yaml
@@ -26,7 +26,9 @@ spec:
     certController:
       create: false
     webhook:
-      timeoutSeconds: 30
+      timeoutSeconds: 60
+      env:
+        WEBHOOK_CLIENT_TIMEOUT: 30s
       certManager:
         enabled: true
         addInjectorAnnotations: true


### PR DESCRIPTION
## Summary
- Increase webhook timeout from 30s to 60s to fix timeout issues with ExternalSecret creation
- Add WEBHOOK_CLIENT_TIMEOUT env var to fix flux controller timeout