### PR TITLE
external-secrets: add certificate yaml to fix issuer

### DIFF
--- a/home-cluster/external-secrets/certificate.yaml
+++ b/home-cluster/external-secrets/certificate.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: external-secrets-webhook
+  namespace: external-secrets
+spec:
+  commonName: external-secrets-webhook
+  dnsNames:
+  - external-secrets-webhook
+  - external-secrets-webhook.external-secrets
+  - external-secrets-webhook.external-secrets.svc
+  duration: 8760h0m0s
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencryt-issuer
+  secretName: external-secrets-webhook

--- a/home-cluster/external-secrets/helmrelease.yaml
+++ b/home-cluster/external-secrets/helmrelease.yaml
@@ -36,4 +36,4 @@ spec:
           issuerRef:
             group: cert-manager.io
             kind: ClusterIssuer
-            name: selfsigned-issuer
+            name: letsencryt-issuer

--- a/home-cluster/external-secrets/kustomization.yaml
+++ b/home-cluster/external-secrets/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - network-policy.yaml
   - helmrepository.yaml
   - helmrelease.yaml
+  - certificate.yaml
   - eso-flux-networkpolicy.yaml


### PR DESCRIPTION
## Summary
- Add certificate as separate YAML to use correct issuer (letsencryt-issuer)
- The helm chart wasn't updating the certificate when helmrelease values changed