### PR TITLE
fix(networkpolicy): allow reflector API egress to kubernetes ClusterIP and webhook ingress from host

### DIFF
--- a/home-cluster/clustersecret/network-policy.yaml
+++ b/home-cluster/clustersecret/network-policy.yaml
@@ -19,6 +19,13 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: kube-system
+  # Kube API server service (ClusterIP)
+  - ports:
+    - protocol: TCP
+      port: 443
+    to:
+    - ipBlock:
+        cidr: 10.152.183.1/32
   # Kube API server (host network, port 6443)
   - ports:
     - protocol: TCP

--- a/home-cluster/external-secrets/eso-flux-networkpolicy.yaml
+++ b/home-cluster/external-secrets/eso-flux-networkpolicy.yaml
@@ -30,6 +30,8 @@ spec:
   ingress:
   - from:
     - namespaceSelector: {}
+    - ipBlock:
+        cidr: 192.168.1.96/32
     ports:
     - protocol: TCP
       port: 10250


### PR DESCRIPTION
## Summary

- **Reflector CrashLoopBackOff fix**: Added egress rule for the Kubernetes service ClusterIP (). The existing  rule only matches traffic to pods in namespaces, not to ClusterIPs. The reflector uses  to connect to the API, which resolves to a ClusterIP.

- **ESO webhook timeout fix**: Added  ingress rule for  (kube-nuc, where the kube-apiserver runs on host network). The existing  only matches traffic from pods in namespaces, not from the host network where the API server runs.

## Root Cause Analysis

Kubernetes NetworkPolicies with  only match traffic to/from pods in namespaces. ClusterIPs and host network traffic don't match these selectors. Two fixes needed:
1. Egress to ClusterIP requires explicit  rule
2. Ingress from host network (kube-apiserver) requires explicit  rule