### PR TITLE
fix(networkpolicy): allow ESO webhook ingress from all node IPs

### DIFF
--- a/home-cluster/external-secrets/eso-flux-networkpolicy.yaml
+++ b/home-cluster/external-secrets/eso-flux-networkpolicy.yaml
@@ -31,7 +31,7 @@ spec:
   - from:
     - namespaceSelector: {}
     - ipBlock:
-        cidr: 192.168.1.96/32
+        cidr: 192.168.1.0/24
     ports:
     - protocol: TCP
       port: 10250


### PR DESCRIPTION
The kube-apiserver runs on all 3 nodes (192.168.1.{49,96,121}) on host network. The webhook ingress rule was restricted to 192.168.1.96/32, so API servers on the other two nodes couldn't reach the webhook, causing timeout errors for all ExternalSecret dry-runs.