### PR TITLE
fix(external-secrets): use hostNetwork for webhook to fix kube-apiserver connectivity

### DIFF
--- a/home-cluster/external-secrets/helmrelease.yaml
+++ b/home-cluster/external-secrets/helmrelease.yaml
@@ -26,6 +26,8 @@ spec:
     certController:
       create: false
     webhook:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       timeoutSeconds: 60
       env:
         WEBHOOK_CLIENT_TIMEOUT: 30s


### PR DESCRIPTION
## Summary
- Sets `hostNetwork: true` and `dnsPolicy: ClusterFirstWithHostNet` for the ESO webhook deployment
- Fixes `context deadline exceeded` errors when kube-apiserver calls the webhook validation endpoint
- The cluster uses Calico BPF mode without kube-proxy, which breaks host-to-pod ClusterIP service routing
- Using hostNetwork allows the kube-apiserver (which runs on host network) to reach the webhook directly via pod IP