### PR TITLE
fix(external-secrets): set webhook port to 9443 with extraArgs

### DIFF
--- a/home-cluster/external-secrets/helmrelease.yaml
+++ b/home-cluster/external-secrets/helmrelease.yaml
@@ -32,6 +32,8 @@ spec:
       timeoutSeconds: 60
       env:
         WEBHOOK_CLIENT_TIMEOUT: 30s
+      extraArgs:
+        - --port=9443
       certManager:
         enabled: true
         addInjectorAnnotations: true


### PR DESCRIPTION
Sets webhook port to 9443 via extraArgs to avoid kubelet port conflict (10250) when using hostNetwork.