### PR TITLE
fix(external-secrets): use object for extraArgs port

### DIFF
--- a/home-cluster/external-secrets/helmrelease.yaml
+++ b/home-cluster/external-secrets/helmrelease.yaml
@@ -33,7 +33,7 @@ spec:
       env:
         WEBHOOK_CLIENT_TIMEOUT: 30s
       extraArgs:
-        - --port=9443
+        port: "9443"
       certManager:
         enabled: true
         addInjectorAnnotations: true


### PR DESCRIPTION
Fixes schema validation error by using object format for extraArgs.