### PR TITLE
fix(vpn): trim leading/trailing spaces from ovpn filename

### DIFF
--- a/home-cluster/vpn/vpn-qbittorent.yaml
+++ b/home-cluster/vpn/vpn-qbittorent.yaml
@@ -59,8 +59,8 @@ spec:
           - sh
           - -c
           - |
-            FILENAME=$(cat /etc/ovpn-secret/filename)
-            cp /etc/ovpn-secret/$FILENAME /etc/ovpn-secret/custom.ovpn
+            FILENAME=$(cat /etc/ovpn-secret/filename | tr -d ' ')
+            cp "/etc/ovpn-secret/$FILENAME" /etc/ovpn-secret/custom.ovpn
         volumeMounts:
         - name: expressvpn-ovpn
           mountPath: /etc/ovpn-secret


### PR DESCRIPTION
Fixes init container failure caused by leading space in 1Password filename field.