### PR TITLE
fix(vpn): copy ovpn_text directly to custom.ovpn

### DIFF
--- a/home-cluster/vpn/vpn-qbittorent.yaml
+++ b/home-cluster/vpn/vpn-qbittorent.yaml
@@ -59,8 +59,7 @@ spec:
           - sh
           - -c
           - |
-            FILENAME=$(cat /etc/ovpn-secret/filename | tr -d ' ')
-            cp "/etc/ovpn-secret/$FILENAME" /etc/ovpn-secret/custom.ovpn
+            cp /etc/ovpn-secret/ovpn_text /etc/ovpn-secret/custom.ovpn
         volumeMounts:
         - name: expressvpn-ovpn
           mountPath: /etc/ovpn-secret


### PR DESCRIPTION
The secret stores ovpn content as ovpn_text, not as a file. Fix init container to copy ovpn_text directly.