### PR TITLE
fix(vpn): switch to TCP protocol for ExpressVPN

### DIFF
--- a/home-cluster/vpn/vpn-qbittorent.yaml
+++ b/home-cluster/vpn/vpn-qbittorent.yaml
@@ -73,8 +73,12 @@ spec:
           value: expressvpn
         - name: VPN_TYPE
           value: openvpn
+        - name: OPENVPN_PROTOCOL
+          value: tcp
         - name: SERVER_COUNTRIES
           value: USA
+        - name: SERVER_REGIONS
+          value: North America
         - name: OPENVPN_USER
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Fixes TLS handshake failures by switching from UDP to TCP and adding SERVER_REGIONS filter.