### PR TITLE
fix(vpn): remove invalid SERVER_REGIONS for ExpressVPN

### DIFF
--- a/home-cluster/vpn/vpn-qbittorent.yaml
+++ b/home-cluster/vpn/vpn-qbittorent.yaml
@@ -77,8 +77,6 @@ spec:
           value: tcp
         - name: SERVER_COUNTRIES
           value: USA
-        - name: SERVER_REGIONS
-          value: North America
         - name: OPENVPN_USER
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
The region 'North America' is not valid for ExpressVPN server selection in gluetun.