### PR TITLE
fix(vpn): remove TCP protocol override

### DIFF
--- a/home-cluster/vpn/vpn-qbittorent.yaml
+++ b/home-cluster/vpn/vpn-qbittorent.yaml
@@ -73,8 +73,6 @@ spec:
           value: expressvpn
         - name: VPN_TYPE
           value: openvpn
-        - name: OPENVPN_PROTOCOL
-          value: tcp
         - name: SERVER_COUNTRIES
           value: USA
         - name: OPENVPN_USER


### PR DESCRIPTION
ExpressVPN only has UDP servers in gluetun's server list. Removing protocol override to let it auto-select.