### PR TITLE
fix(vpn): allow internet egress in NetworkPolicy

### DIFF
--- a/home-cluster/vpn/network-policy.yaml
+++ b/home-cluster/vpn/network-policy.yaml
@@ -22,6 +22,7 @@ spec:
       port: 443
   - to:
     - namespaceSelector: {}
+  - {}
   ingress:
   - from:
     - namespaceSelector: {}


### PR DESCRIPTION
The VPN pod needs to reach VPN servers on the internet (UDP 1195). The NetworkPolicy was missing an egress rule for external traffic.