### PR TITLE
fix(vpn): restore custom ovpn config

### DIFF
--- a/home-cluster/vpn/external-secrets-ovpn.yaml
+++ b/home-cluster/vpn/external-secrets-ovpn.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: expressvpn-ovpn
+spec:
+  refreshInterval: 168h
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+  target:
+    name: expressvpn-ovpn
+    creationPolicy: Owner
+  data:
+    - secretKey: ovpn_text
+      remoteRef:
+        key: express-vpn-auth
+        property: ovpn_text

--- a/home-cluster/vpn/kustomization.yaml
+++ b/home-cluster/vpn/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - vpn-qbittorent.yaml
   - ingressroute-qbittorrent.yaml
   - external-secrets.yaml
+  - external-secrets-ovpn.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/home-cluster/vpn/vpn-qbittorent.yaml
+++ b/home-cluster/vpn/vpn-qbittorent.yaml
@@ -53,6 +53,19 @@ spec:
           mountPath: /config
         - name: config-init
           mountPath: /config-init
+      - name: setup-ovpn
+        image: busybox:1.36
+        command:
+          - sh
+          - -c
+          - |
+            cp /etc/ovpn-secret/ovpn_text /etc/ovpn-config/custom.ovpn
+        volumeMounts:
+        - name: expressvpn-ovpn
+          mountPath: /etc/ovpn-secret
+          readOnly: true
+        - name: ovpn-config
+          mountPath: /etc/ovpn-config
       containers:
       - name: gluetun
         image: qmcgaw/gluetun:latest
@@ -70,11 +83,11 @@ spec:
           periodSeconds: 10
         env:
         - name: VPN_SERVICE_PROVIDER
-          value: expressvpn
+          value: custom
         - name: VPN_TYPE
           value: openvpn
-        - name: SERVER_COUNTRIES
-          value: USA
+        - name: OPENVPN_CUSTOM_CONFIG
+          value: /etc/ovpn-config/custom.ovpn
         - name: OPENVPN_USER
           valueFrom:
             secretKeyRef:
@@ -93,6 +106,8 @@ spec:
           value: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fd00::/8,1.1.1.1/32,1.0.0.1/32,8.8.8.8/32,8.8.4.4/32"
         - name: FIREWALL_INPUT_PORTS
           value: "8080"
+        - name: FIREWALL_VPN_ENDPOINT_IP
+          value: "1"
         - name: HEALTH_CHECK_PERIOD
           value: "30"
         - name: HEALTH_TARGET_ADDRESS
@@ -103,6 +118,9 @@ spec:
         volumeMounts:
         - name: downloads
           mountPath: /downloads
+        - name: ovpn-config
+          mountPath: /etc/ovpn-config
+          readOnly: true
       - name: qbittorrent
         image: linuxserver/qbittorrent:latest
         readinessProbe:
@@ -142,6 +160,11 @@ spec:
         hostPath:
           path: /mnt/nas/torrents/Downloads
           type: Directory
+      - name: expressvpn-ovpn
+        secret:
+          secretName: expressvpn-ovpn
+      - name: ovpn-config
+        emptyDir: {}
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
Restores custom OpenVPN config from 1Password. Gluetun's built-in ExpressVPN provider fails TLS handshake. Uses emptyDir volume so init container can copy ovpn_text to a writable location.