### PR TITLE
feat(media): migrate Overseerr to Seerr

### DIFF
--- a/home-cluster/media/ingressroute-seerr.yaml
+++ b/home-cluster/media/ingressroute-seerr.yaml
@@ -1,7 +1,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
-  name: overseerr
+  name: seerr
   namespace: media
   annotations:
     external-dns.alpha.kubernetes.io/hostname: overseerr.kube.stevearnett.com
@@ -13,7 +13,7 @@ spec:
     - match: Host(`overseerr.kube.stevearnett.com`)
       kind: Rule
       services:
-        - name: overseerr
+        - name: seerr
           port: 5055
   tls:
     secretName: wildcard-stevearnett-com-tls

--- a/home-cluster/media/kustomization.yaml
+++ b/home-cluster/media/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
   - namespace.yaml
   - jellyfin-helmrepository.yaml
   - jellyfin-helmrelease.yaml
-  - overseerr.yaml
+  - seerr.yaml
   - prowlarr.yaml
   - radarr.yaml
   - sonarr.yaml
@@ -16,7 +16,7 @@ resources:
   - lidarr.yaml
   - ingressroute-jellyfin.yaml
   - ingressroute-lidarr.yaml
-  - ingressroute-overseerr.yaml
+  - ingressroute-seerr.yaml
   - ingressroute-prowlarr.yaml
   - ingressroute-radarr.yaml
   - ingressroute-sonarr.yaml

--- a/home-cluster/media/seerr.yaml
+++ b/home-cluster/media/seerr.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: overseerr
+  name: seerr
   namespace: media
   annotations:
     kubernetes.io/ingress.class: traefik
@@ -21,14 +21,14 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: overseerr
+            name: seerr
             port:
               number: 5055
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: overseerr-config
+  name: seerr-config
   namespace: media
 spec:
   accessModes:
@@ -41,22 +41,32 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: overseerr
+  name: seerr
   namespace: media
+  labels:
+    alert-on-down: "true"
 spec:
   replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: overseerr
+      app: seerr
   template:
     metadata:
       labels:
-        app: overseerr
+        app: seerr
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
-      - name: overseerr
-        image: sctx/overseerr:latest
+      - name: seerr
+        image: seerr/seerr:latest
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
         env:
         - name: LOG_LEVEL
           value: info
@@ -66,21 +76,21 @@ spec:
         - containerPort: 5055
           protocol: TCP
         volumeMounts:
-        - name: overseerr-config
+        - name: seerr-config
           mountPath: /app/config
       volumes:
-      - name: overseerr-config
+      - name: seerr-config
         persistentVolumeClaim:
-          claimName: overseerr-config
+          claimName: seerr-config
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: overseerr
+  name: seerr
   namespace: media
 spec:
   selector:
-    app: overseerr
+    app: seerr
   ports:
   - port: 5055
     targetPort: 5055


### PR DESCRIPTION
Migrates from Overseerr to Seerr, the unified successor project.

## Changes
- Replaces `sctx/overseerr:latest` with `seerr/seerr:latest`
- Adds securityContext for non-root user (UID 1000) as required by Seerr
- Renames resources from `overseerr` to `seerr`
- Keeps same hostname (`overseerr.kube.stevearnett.com`) for seamless URL continuity
- Seerr auto-migrates Overseerr data on first startup