### PR TITLE
fix(media): allow internet egress in NetworkPolicy

### DIFF
--- a/home-cluster/media/network-policy.yaml
+++ b/home-cluster/media/network-policy.yaml
@@ -22,6 +22,7 @@ spec:
       port: 443
   - to:
     - namespaceSelector: {}
+  - {}
   ingress:
   - from:
     - namespaceSelector:


### PR DESCRIPTION
Seerr and other media services need internet access for Jellyfin, TMDB, GitHub updates, anime lists, etc.