### PR TITLE
fix(frigate): add 3-day recording retention to prevent disk fill

### DIFF
--- a/home-cluster/frigate/configmap.yaml
+++ b/home-cluster/frigate/configmap.yaml
@@ -24,6 +24,16 @@ data:
     detect:
       enabled: true
     
+    record:
+      enabled: true
+      retain:
+        days: 3
+        mode: all
+      events:
+        retain:
+          default: 7
+          mode: motion
+    
     cameras:
       driveway:
         enabled: true
@@ -51,10 +61,12 @@ data:
             coordinates: 0.227,0.289,0.384,0.268,0.634,0.32,0.784,0.993,0.084,0.986,0.049,0.75,0.09,0.511,0.186,0.257
             loitering_time: 0
             friendly_name: Driveway
+            inertia: 3
           mailbox:
             coordinates: 0.647,0.218,0.725,0.225,0.752,0.239,0.785,0.275,0.796,0.342,0.727,0.324,0.691,0.327
             loitering_time: 0
             friendly_name: Mailbox
+            inertia: 3
         motion:
           mask: 0.403,0,0.403,0.053,0.583,0.06,0.582,0
         record:


### PR DESCRIPTION
Frigate was keeping all continuous recordings forever. Added:
- Global `record.retain.days: 3` (mode: all) — auto-deletes continuous recordings older than 3 days
- Global `record.events.retain.default: 7` (mode: motion) — keeps motion events for 7 days