### PR TITLE
fix(frigate): move media storage from local PVC to NAS hostPath

### DIFF
--- a/home-cluster/frigate/deployment.yaml
+++ b/home-cluster/frigate/deployment.yaml
@@ -76,8 +76,9 @@ spec:
           configMap:
             name: frigate-config
         - name: media
-          persistentVolumeClaim:
-            claimName: frigate-media-pvc
+          hostPath:
+            path: /mnt/nas/frigate
+            type: DirectoryOrCreate
         - name: cache
           emptyDir:
             medium: Memory


### PR DESCRIPTION
Changes frigate media storage from local PVC to /mnt/nas/frigate on the host NAS. Prevents node disk fill from camera recordings.