### PR TITLE
fix(frigate): fix config for 0.17 compatibility

### DIFF
--- a/home-cluster/frigate/configmap.yaml
+++ b/home-cluster/frigate/configmap.yaml
@@ -24,6 +24,18 @@ data:
     detect:
       enabled: true
     
+    record:
+      enabled: true
+      retain:
+        days: 3
+        mode: all
+      events:
+        pre_capture: 5
+        post_capture: 5
+        retain:
+          days: 7
+          mode: motion
+    
     cameras:
       driveway:
         enabled: true
@@ -61,13 +73,6 @@ data:
           mask: 0.403,0,0.403,0.053,0.583,0.06,0.582,0
         record:
           enabled: true
-          retain:
-            days: 3
-            mode: all
-          events:
-            retain:
-              days: 7
-              mode: motion
       
       play_yard:
         enabled: true
@@ -90,13 +95,6 @@ data:
           mask: 0.408,0,0.408,0.06,0.588,0.06,0.588,0
         record:
           enabled: true
-          retain:
-            days: 3
-            mode: all
-          events:
-            retain:
-              days: 7
-              mode: motion
 
       dining_room:
         enabled: true
@@ -114,13 +112,6 @@ data:
           mask: 0.281,0.008,0.28,0.07,0.704,0.072,0.708,0
         record:
           enabled: true
-          retain:
-            days: 3
-            mode: all
-          events:
-            retain:
-              days: 7
-              mode: motion
 
     version: 0.17-0
 


### PR DESCRIPTION
Moves retention settings to global level. Frigate 0.17 doesn't support per-camera record.retain.