### PR TITLE
fix(frigate): update global record config to Frigate 0.17 schema

### DIFF
--- a/home-cluster/frigate/configmap.yaml
+++ b/home-cluster/frigate/configmap.yaml
@@ -26,15 +26,10 @@ data:
     
     record:
       enabled: true
-      retain:
+      continuous:
         days: 3
-        mode: all
-      events:
-        pre_capture: 5
-        post_capture: 5
-        retain:
-          days: 7
-          mode: motion
+      motion:
+        days: 7
     
     cameras:
       driveway:


### PR DESCRIPTION
## Summary

- Fix Frigate config validation errors in safe mode caused by pre-0.17 record schema
- Replace invalid `retain` and `events` keys with Frigate 0.17's tiered retention: `continuous` (3 days) and `motion` (7 days)
- Previous PR #432 moved retention to global level but didn't update to the 0.17 schema

## Changes

- `frigate/configmap.yaml`: Updated global `record` section from old structure to 0.17-compatible tiered retention