### PR TITLE
fix(media): allow inter-pod ingress for Prowlarr -> FlareSolverr connectivity

### DIFF
--- a/home-cluster/media/network-policy.yaml
+++ b/home-cluster/media/network-policy.yaml
@@ -28,3 +28,5 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: traefik
+  - from:
+    - podSelector: {}


### PR DESCRIPTION
## Summary\n\n- Add podSelector ingress rule to media NetworkPolicy to allow inter-pod communication within the media namespace\n- Fixes Prowlarr timeout connecting to FlareSolverr (http://flaresolverr:8191)\n\nThe existing NetworkPolicy only allowed ingress from the traefik namespace, which blocked Prowlarr from reaching FlareSolverr despite both being in the same namespace.