### PR TITLE
fix(cert-manager): allow external HTTPS egress for ACME/Lets Encrypt renewal

### DIFF
--- a/home-cluster/cert-manager/network-policy.yaml
+++ b/home-cluster/cert-manager/network-policy.yaml
@@ -23,6 +23,12 @@ spec:
     ports:
     - protocol: TCP
       port: 443
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    - protocol: TCP
+      port: 443
   ingress:
   - from:
     - namespaceSelector:


### PR DESCRIPTION
## Summary

- **Problem**: Cert-manager's NetworkPolicy blocked egress to external IPs on port 443. The `namespaceSelector: {}` rule only covers pod-to-pod traffic inside the cluster, not traffic to external IPs like Let's Encrypt's ACME endpoint or Cloudflare API.
- **Fix**: Added an `ipBlock: 0.0.0.0/0` egress rule on port 443 so cert-manager can reach external HTTPS endpoints.
- **Result**: The wildcard certificate expired today (Jun 17) because cert-manager couldn't reach `acme-v02.api.letsencrypt.org:443` — `dial tcp 172.65.32.248:443: i/o timeout`. This exposes the same gap the previous `fix/cert-manager-egress` PR tried to address but missed the `ipBlock` rule.

## Previous Attempt

`fix/cert-manager-egress` added the `namespaceSelector: {}` rule (pod-to-pod), but cert-manager also needs to reach **external** HTTPS endpoints for ACME registration and DNS-01 challenges. That's what this PR adds.