### PR TITLE
fix(cert-manager): allow external DNS egress for ACME DNS-01 propagation checks

### DIFF
--- a/home-cluster/cert-manager/network-policy.yaml
+++ b/home-cluster/cert-manager/network-policy.yaml
@@ -19,6 +19,14 @@ spec:
     - protocol: TCP
       port: 53
   - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  - to:
     - namespaceSelector: {}
     ports:
     - protocol: TCP


### PR DESCRIPTION
## Summary

- **Problem**: Cert-manager's DNS-01 propagation checks need to directly query Cloudflare's authoritative nameservers (e.g., `172.64.34.17:53`) to verify TXT records. The NetworkPolicy only allowed DNS egress to `kube-system` (internal cluster DNS).
- **Logs**: `dial tcp 172.64.34.17:53: i/o timeout` — same pattern as the HTTPS egress bug fixed in PR #441.
- **Fix**: Added `ipBlock: 0.0.0.0/0` egress rule for port 53 (UDP and TCP) so cert-manager can query external DNS servers for propagation checks.

## Note

This builds on PR #441 which fixed the HTTPS egress. The ACME order is now placed successfully but the DNS-01 challenge cannot complete because propagation checks fail.