### PR TITLE
feat(traefik): remove tls.secretName from all IngressRoutes to use default certificate

### DIFF
--- a/home-cluster/ai-services/ingressroute-comfy.yaml
+++ b/home-cluster/ai-services/ingressroute-comfy.yaml
@@ -20,5 +20,4 @@ spec:
         - name: comfy-local
           port: 8080
           scheme: http
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/ai-services/ingressroute-dolphin.yaml
+++ b/home-cluster/ai-services/ingressroute-dolphin.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: ollama
           port: 11434
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/ai-services/ingressroute-pigallery2.yaml
+++ b/home-cluster/ai-services/ingressroute-pigallery2.yaml
@@ -17,5 +17,4 @@ spec:
         - name: pigallery2
           port: 80
           scheme: http
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/frigate/ingressroute.yaml
+++ b/home-cluster/frigate/ingressroute.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: frigate
           port: 5000
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/headlamp/ingressroute.yaml
+++ b/home-cluster/headlamp/ingressroute.yaml
@@ -12,5 +12,4 @@ spec:
       services:
         - name: headlamp
           port: 80
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/home-assistant/ingressroute.yaml
+++ b/home-cluster/home-assistant/ingressroute.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: home-assistant
           port: 8123
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/local-services/ingress-nas.yaml
+++ b/home-cluster/local-services/ingress-nas.yaml
@@ -13,7 +13,6 @@ spec:
   tls:
   - hosts:
     - nas.stevearnett.com
-    secretName: wildcard-stevearnett-com-tls
   rules:
   - host: nas.stevearnett.com
     http:

--- a/home-cluster/local-services/ingress-zb.yaml
+++ b/home-cluster/local-services/ingress-zb.yaml
@@ -13,7 +13,6 @@ spec:
   tls:
   - hosts:
     - zb.stevearnett.com
-    secretName: wildcard-stevearnett-com-tls
   rules:
   - host: zb.stevearnett.com
     http:

--- a/home-cluster/local-services/ingressroute-unifi.yaml
+++ b/home-cluster/local-services/ingressroute-unifi.yaml
@@ -19,5 +19,4 @@ spec:
           port: 443
           scheme: https
           serversTransport: insecure-transport
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/media/ingressroute-jellyfin.yaml
+++ b/home-cluster/media/ingressroute-jellyfin.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: jellyfin
           port: 8096
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/media/ingressroute-lidarr.yaml
+++ b/home-cluster/media/ingressroute-lidarr.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: lidarr
           port: 8686
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/media/ingressroute-prowlarr.yaml
+++ b/home-cluster/media/ingressroute-prowlarr.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: prowlarr
           port: 9696
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/media/ingressroute-radarr.yaml
+++ b/home-cluster/media/ingressroute-radarr.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: radarr
           port: 7878
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/media/ingressroute-seerr.yaml
+++ b/home-cluster/media/ingressroute-seerr.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: seerr
           port: 5055
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/media/ingressroute-sonarr.yaml
+++ b/home-cluster/media/ingressroute-sonarr.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: sonarr
           port: 8989
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/media/lidarr.yaml
+++ b/home-cluster/media/lidarr.yaml
@@ -12,7 +12,6 @@ spec:
   tls:
   - hosts:
     - lidarr.kube.stevearnett.com
-    secretName: wildcard-stevearnett-com-tls
   rules:
   - host: lidarr.kube.stevearnett.com
     http:

--- a/home-cluster/media/prowlarr.yaml
+++ b/home-cluster/media/prowlarr.yaml
@@ -12,7 +12,6 @@ spec:
   tls:
   - hosts:
     - prowlarr.kube.stevearnett.com
-    secretName: wildcard-stevearnett-com-tls
   rules:
   - host: prowlarr.kube.stevearnett.com
     http:

--- a/home-cluster/media/radarr.yaml
+++ b/home-cluster/media/radarr.yaml
@@ -12,7 +12,6 @@ spec:
   tls:
   - hosts:
     - radarr.kube.stevearnett.com
-    secretName: wildcard-stevearnett-com-tls
   rules:
   - host: radarr.kube.stevearnett.com
     http:

--- a/home-cluster/media/seerr.yaml
+++ b/home-cluster/media/seerr.yaml
@@ -12,7 +12,6 @@ spec:
   tls:
   - hosts:
     - overseerr.kube.stevearnett.com
-    secretName: wildcard-stevearnett-com-tls
   rules:
   - host: overseerr.kube.stevearnett.com
     http:

--- a/home-cluster/media/sonarr.yaml
+++ b/home-cluster/media/sonarr.yaml
@@ -12,7 +12,6 @@ spec:
   tls:
   - hosts:
     - sonarr.kube.stevearnett.com
-    secretName: wildcard-stevearnett-com-tls
   rules:
   - host: sonarr.kube.stevearnett.com
     http:

--- a/home-cluster/meshtastic/ingressroute.yaml
+++ b/home-cluster/meshtastic/ingressroute.yaml
@@ -15,8 +15,7 @@ spec:
       services:
         - name: meshmonitor
           port: 3001
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP

--- a/home-cluster/monitoring/ingressroute-alertmanager.yaml
+++ b/home-cluster/monitoring/ingressroute-alertmanager.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: kube-prometheus-stack-alertmanager
           port: 9093
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/monitoring/ingressroute-grafana.yaml
+++ b/home-cluster/monitoring/ingressroute-grafana.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: kube-prometheus-stack-grafana
           port: 80
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/monitoring/ingressroute-prometheus.yaml
+++ b/home-cluster/monitoring/ingressroute-prometheus.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: kube-prometheus-stack-prometheus
           port: 9090
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/netalertx/ingressroute.yaml
+++ b/home-cluster/netalertx/ingressroute.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: netalertx
           port: 20211
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/oauth2-proxy/ingress-auth.yaml
+++ b/home-cluster/oauth2-proxy/ingress-auth.yaml
@@ -11,7 +11,6 @@ spec:
   tls:
   - hosts:
     - auth.kube.stevearnett.com
-    secretName: wildcard-stevearnett-com-tls
   rules:
   - host: auth.kube.stevearnett.com
     http:

--- a/home-cluster/oauth2-proxy/ingress-dashboard.yaml
+++ b/home-cluster/oauth2-proxy/ingress-dashboard.yaml
@@ -13,7 +13,6 @@ spec:
   tls:
   - hosts:
     - dashboard.kube.stevearnett.com
-    secretName: wildcard-stevearnett-com-tls
   rules:
   - host: dashboard.kube.stevearnett.com
     http:

--- a/home-cluster/plex/ingressroute.yaml
+++ b/home-cluster/plex/ingressroute.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: plex-plex-media-server
           port: 32400
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/registry/ingressroute.yaml
+++ b/home-cluster/registry/ingressroute.yaml
@@ -15,5 +15,4 @@ spec:
     services:
     - name: registry
       port: 5000
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/speedtest/ingressroute.yaml
+++ b/home-cluster/speedtest/ingressroute.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: speedtest-tracker
           port: 80
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/traefik/ingress-dashboard.yaml
+++ b/home-cluster/traefik/ingress-dashboard.yaml
@@ -12,5 +12,4 @@ spec:
       services:
         - name: api@internal
           kind: TraefikService
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}

--- a/home-cluster/vpn/ingressroute-qbittorrent.yaml
+++ b/home-cluster/vpn/ingressroute-qbittorrent.yaml
@@ -15,5 +15,4 @@ spec:
       services:
         - name: gluetun
           port: 8080
-  tls:
-    secretName: wildcard-stevearnett-com-tls
+  tls: {}


### PR DESCRIPTION
Stage 2 of migrating to edge-terminated TLS at Traefik (follow-up to #444).

Problem: After moving the wildcard Certificate to the traefik/ namespace in Stage 1, the old reflector-mirrored TLS secrets (with expired certs) remained in every namespace. Since all IngressRoutes specified tls.secretName, Traefik found the stale local copy and served the expired cert.

Fix: Remove tls.secretName from all 23 IngressRoutes and 9 standard Ingress objects. With Traefik's defaultCertificate configured on the websecure entrypoint, Traefik now uses the valid wildcard cert from its own namespace.

Files changed (32):
- 23 IngressRoute files: tls: { secretName: ... } -> tls: {}
- 9 standard Ingress files: removed secretName from TLS list entries