### PR TITLE
fix(traefik): remove empty tls block from IngressRoutes (CRD rejects tls: {})

### DIFF
--- a/home-cluster/ai-services/ingressroute-comfy.yaml
+++ b/home-cluster/ai-services/ingressroute-comfy.yaml
@@ -20,4 +20,3 @@ spec:
         - name: comfy-local
           port: 8080
           scheme: http
-  tls: {}

--- a/home-cluster/ai-services/ingressroute-dolphin.yaml
+++ b/home-cluster/ai-services/ingressroute-dolphin.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: ollama
           port: 11434
-  tls: {}

--- a/home-cluster/ai-services/ingressroute-pigallery2.yaml
+++ b/home-cluster/ai-services/ingressroute-pigallery2.yaml
@@ -17,4 +17,3 @@ spec:
         - name: pigallery2
           port: 80
           scheme: http
-  tls: {}

--- a/home-cluster/frigate/ingressroute.yaml
+++ b/home-cluster/frigate/ingressroute.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: frigate
           port: 5000
-  tls: {}

--- a/home-cluster/headlamp/ingressroute.yaml
+++ b/home-cluster/headlamp/ingressroute.yaml
@@ -12,4 +12,3 @@ spec:
       services:
         - name: headlamp
           port: 80
-  tls: {}

--- a/home-cluster/home-assistant/ingressroute.yaml
+++ b/home-cluster/home-assistant/ingressroute.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: home-assistant
           port: 8123
-  tls: {}

--- a/home-cluster/local-services/ingressroute-unifi.yaml
+++ b/home-cluster/local-services/ingressroute-unifi.yaml
@@ -19,4 +19,3 @@ spec:
           port: 443
           scheme: https
           serversTransport: insecure-transport
-  tls: {}

--- a/home-cluster/media/ingressroute-jellyfin.yaml
+++ b/home-cluster/media/ingressroute-jellyfin.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: jellyfin
           port: 8096
-  tls: {}

--- a/home-cluster/media/ingressroute-lidarr.yaml
+++ b/home-cluster/media/ingressroute-lidarr.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: lidarr
           port: 8686
-  tls: {}

--- a/home-cluster/media/ingressroute-prowlarr.yaml
+++ b/home-cluster/media/ingressroute-prowlarr.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: prowlarr
           port: 9696
-  tls: {}

--- a/home-cluster/media/ingressroute-radarr.yaml
+++ b/home-cluster/media/ingressroute-radarr.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: radarr
           port: 7878
-  tls: {}

--- a/home-cluster/media/ingressroute-seerr.yaml
+++ b/home-cluster/media/ingressroute-seerr.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: seerr
           port: 5055
-  tls: {}

--- a/home-cluster/media/ingressroute-sonarr.yaml
+++ b/home-cluster/media/ingressroute-sonarr.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: sonarr
           port: 8989
-  tls: {}

--- a/home-cluster/meshtastic/ingressroute.yaml
+++ b/home-cluster/meshtastic/ingressroute.yaml
@@ -15,7 +15,6 @@ spec:
       services:
         - name: meshmonitor
           port: 3001
-  tls: {}
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP

--- a/home-cluster/monitoring/ingressroute-alertmanager.yaml
+++ b/home-cluster/monitoring/ingressroute-alertmanager.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: kube-prometheus-stack-alertmanager
           port: 9093
-  tls: {}

--- a/home-cluster/monitoring/ingressroute-grafana.yaml
+++ b/home-cluster/monitoring/ingressroute-grafana.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: kube-prometheus-stack-grafana
           port: 80
-  tls: {}

--- a/home-cluster/monitoring/ingressroute-prometheus.yaml
+++ b/home-cluster/monitoring/ingressroute-prometheus.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: kube-prometheus-stack-prometheus
           port: 9090
-  tls: {}

--- a/home-cluster/netalertx/ingressroute.yaml
+++ b/home-cluster/netalertx/ingressroute.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: netalertx
           port: 20211
-  tls: {}

--- a/home-cluster/plex/ingressroute.yaml
+++ b/home-cluster/plex/ingressroute.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: plex-plex-media-server
           port: 32400
-  tls: {}

--- a/home-cluster/registry/ingressroute.yaml
+++ b/home-cluster/registry/ingressroute.yaml
@@ -15,4 +15,3 @@ spec:
     services:
     - name: registry
       port: 5000
-  tls: {}

--- a/home-cluster/speedtest/ingressroute.yaml
+++ b/home-cluster/speedtest/ingressroute.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: speedtest-tracker
           port: 80
-  tls: {}

--- a/home-cluster/traefik/ingress-dashboard.yaml
+++ b/home-cluster/traefik/ingress-dashboard.yaml
@@ -12,4 +12,3 @@ spec:
       services:
         - name: api@internal
           kind: TraefikService
-  tls: {}

--- a/home-cluster/vpn/ingressroute-qbittorrent.yaml
+++ b/home-cluster/vpn/ingressroute-qbittorrent.yaml
@@ -15,4 +15,3 @@ spec:
       services:
         - name: gluetun
           port: 8080
-  tls: {}


### PR DESCRIPTION
Fixes Flux dry-run failures caused by PR #445.

tls: {} is treated as null by the Traefik CRD validation, so all IngressRoutes in every namespace entered a failed state.

Fix: completely remove the tls block from all 23 IngressRoute files. Traefik's websecure entrypoint still terminates TLS using the default certificate (the valid wildcard cert in the traefik/ namespace).