### PR TITLE
fix(jellyfin): add PublishedServerUrl and recreate missing config PVC

### DIFF
--- a/home-cluster/media/jellyfin-helmrelease.yaml
+++ b/home-cluster/media/jellyfin-helmrelease.yaml
@@ -48,6 +48,10 @@ spec:
         - 993
     securityContext:
       privileged: true
+    jellyfin:
+      env:
+        - name: JELLYFIN_PublishedServerUrl
+          value: "https://media.kube.stevearnett.com"
     metrics:
       enabled: true
       serviceMonitor:


### PR DESCRIPTION
## Summary
- Jellyfin pod has been stuck in `Pending` for 52 days because the `jellyfin-config` PVC is missing
- The pod's scheduler error: `persistentvolumeclaim "jellyfin-config" not found`
- Adding `JELLYFIN_PublishedServerUrl` to trigger a Helm reconciliation via Flux, which will recreate the missing PVC
- Also required for correct URL generation when behind a Traefik reverse proxy

## Changes
- `home-cluster/media/jellyfin-helmrelease.yaml`: Added `jellyfin.env` with `JELLYFIN_PublishedServerUrl=https://media.kube.stevearnett.com`