### PR TITLE
fix(frigate): upgrade to 0.17.1 with explicit detect resolutions

### DIFF
--- a/home-cluster/frigate/configmap.yaml
+++ b/home-cluster/frigate/configmap.yaml
@@ -34,6 +34,9 @@ data:
     cameras:
       driveway:
         enabled: true
+        detect:
+          width: 5120
+          height: 1552
         ffmpeg:
           inputs:
             - path: rtsp://{FRIGATE_RTSP_USERNAME}:{FRIGATE_RTSP_PASSWORD}@192.168.1.213:554/Preview_01_main
@@ -72,6 +75,9 @@ data:
       play_yard:
         enabled: true
         friendly_name: Play Yard
+        detect:
+          width: 5120
+          height: 1552
         ffmpeg:
           inputs:
             - path: rtsp://{FRIGATE_RTSP_USERNAME}:{FRIGATE_RTSP_PASSWORD}@192.168.1.150:554/Preview_01_main
@@ -94,6 +100,9 @@ data:
       dining_room:
         enabled: true
         friendly_name: Dining Room
+        detect:
+          width: 3840
+          height: 2160
         ffmpeg:
           inputs:
             - path: rtsp://{FRIGATE_RTSP_USERNAME}:{FRIGATE_RTSP_PASSWORD}@192.168.1.184:554/Preview_01_main
@@ -111,6 +120,9 @@ data:
       garage:
         enabled: true
         friendly_name: Garage
+        detect:
+          width: 2560
+          height: 1440
         ffmpeg:
           inputs:
             - path: rtsp://{FRIGATE_RTSP_USERNAME}:{FRIGATE_RTSP_PASSWORD}@192.168.1.77:554/Preview_01_main
@@ -125,7 +137,7 @@ data:
         record:
           enabled: true
 
-    version: 0.16
+    version: 0.17
 
     semantic_search:
       enabled: false

--- a/home-cluster/frigate/deployment.yaml
+++ b/home-cluster/frigate/deployment.yaml
@@ -26,7 +26,7 @@ spec:
                       - kube-nuc
       initContainers:
       - name: copy-config
-        image: ghcr.io/blakeblackshear/frigate:0.16.4
+        image: ghcr.io/blakeblackshear/frigate:0.17.1
         command:
         - sh
         - -c
@@ -40,7 +40,7 @@ spec:
           mountPath: /config-src
       containers:
         - name: frigate
-          image: ghcr.io/blakeblackshear/frigate:0.16.4
+          image: ghcr.io/blakeblackshear/frigate:0.17.1
           envFrom:
             - secretRef:
                 name: frigate-credentials


### PR DESCRIPTION
## Summary

Upgrade Frigate to 0.17.1, which fixes the two bugs introduced in 0.17.0 (env var substitution and go2rtc config). Also adds explicit detect resolutions to work around 0.17.0's broken auto-detection that caused the startup hang.

### Changes
- `deployment.yaml`: `:0.16.4` → `:0.17.1`
- `configmap.yaml`: Add `detect` width/height for all cameras, bump `version` to `0.17`

### Camera resolutions (probed via ffprobe)
| Camera | Resolution |
|---|---|
| driveway | 5120x1552 |
| play_yard | 5120x1552 |
| dining_room | 3840x2160 |
| garage | 2560x1440 |