### PR TITLE
fix(frigate): set deployment strategy to Recreate

### DIFF
--- a/home-cluster/frigate/deployment.yaml
+++ b/home-cluster/frigate/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: frigate
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: frigate


### PR DESCRIPTION
Prevents port conflicts during rollout by terminating the old pod before starting the new one (Frigate binds ports 5000, 8554, 8555).