### PR TITLE
fix(vpn): change downloads volume to DirectoryOrCreate

### DIFF
--- a/home-cluster/vpn/vpn-qbittorent.yaml
+++ b/home-cluster/vpn/vpn-qbittorent.yaml
@@ -168,7 +168,7 @@ spec:
       - name: downloads
         hostPath:
           path: /mnt/nas/torrents/Downloads
-          type: Directory
+          type: DirectoryOrCreate
       - name: expressvpn-ovpn
         secret:
           secretName: expressvpn-ovpn


### PR DESCRIPTION
Fixes pod hang on startup when /mnt/nas/torrents/Downloads doesn't exist on the node.