### PR TITLE
fix: scale down problematic deployments to 0 replicas

### DIFF
--- a/home-cluster/cloudflared/deployment.yaml
+++ b/home-cluster/cloudflared/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cloudflared
   namespace: cloudflared
 spec:
-  replicas: 1
+  replicas: 0
   revisionHistoryLimit: 3
   selector:
     matchLabels:

--- a/home-cluster/meshtastic-bot/deployment.yaml
+++ b/home-cluster/meshtastic-bot/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: meshtastic-bot
   namespace: meshtastic
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: meshtastic-bot

--- a/home-cluster/monitoring/kube-prometheus-stack-helmrelease.yaml
+++ b/home-cluster/monitoring/kube-prometheus-stack-helmrelease.yaml
@@ -65,6 +65,7 @@ spec:
                   description: "Cannot reach {{ $labels.instance }} for 2 minutes"
     grafana:
       enabled: true
+      replicas: 0
       admin:
         existingSecret: grafana-admin-secret
         userKey: admin-user

--- a/home-cluster/plex/helmrelease.yaml
+++ b/home-cluster/plex/helmrelease.yaml
@@ -19,6 +19,7 @@ spec:
     remediation:
       retries: 3
   values:
+    replicas: 0
     service:
       type: ClusterIP
     ingress:


### PR DESCRIPTION
**Problem:** cloudflared, meshtastic-bot, plex, and grafana are stuck in
CrashLoopBackOff/Pending/ContainerCreating after the disk-pressure eviction
event on July 25. They keep restarting and consuming resources.

**Changes:**
- `cloudflared` — replicas 1→0
- `meshtastic-bot` — replicas 1→0
- `plex` — added `replicas: 0`
- `grafana` — added `grafana.replicas: 0`

**Not covered in this PR (need manual intervention):**
- `pihole` — not managed by Flux (legacy helmfile), will need manual kubectl delete
- `cert-manager-cainjector` — bootstrapped externally, not in repo manifests