### PR TITLE
fix: allow cert-manager egress to API server on port 16443

### DIFF
--- a/home-cluster/cert-manager/network-policy.yaml
+++ b/home-cluster/cert-manager/network-policy.yaml
@@ -31,12 +31,16 @@ spec:
     ports:
     - protocol: TCP
       port: 443
+    - protocol: TCP
+      port: 16443
   - to:
     - ipBlock:
         cidr: 0.0.0.0/0
     ports:
     - protocol: TCP
       port: 443
+    - protocol: TCP
+      port: 16443
   ingress:
   - from:
     - namespaceSelector:


### PR DESCRIPTION
The API server listens on port 16443 (custom), but the cert-manager NetworkPolicy only allowed egress on port 443. After DNAT from kubernetes service (443 -> 16443), packets were dropped.

Fix: Added port 16443 to both egress rules.

After merging, scale cainjector back up: `kubectl scale deployment -n cert-manager cert-manager-cainjector --replicas=1`