### PR TITLE
fix: enable TRUST_PROXY for meshmonitor behind Traefik

### DIFF
--- a/home-cluster/meshtastic/deployment.yaml
+++ b/home-cluster/meshtastic/deployment.yaml
@@ -34,6 +34,8 @@ spec:
             secretKeyRef:
               name: meshtastic-admin
               key: ADMIN_USERNAME
+        - name: TRUST_PROXY
+          value: "true"
         - name: COOKIE_SECURE
           value: "true"
         - name: ENABLE_VIRTUAL_NODE


### PR DESCRIPTION
## Summary
- MeshMonitor auto-upgraded from 3.0.0-rc3 to 4.13.1 via the `:latest` tag
- v4.13+ changed `TRUST_PROXY` to default to `false`
- Behind Traefik, the app now sees plain HTTP and never emits the secure session cookie → login fails with CSRF errors
- Add `TRUST_PROXY=true` to restore session cookies through the reverse proxy

## Verification
- `kubectl kustomize meshtastic` passes
- Root cause confirmed in express-session source (`index.js:242`): "only send secure cookies via https" — without TRUST_PROXY, `req.secure` is false behind Traefik
- DB config intact (source 192.168.1.43:4403, 1803 nodes, admin user) — no data loss